### PR TITLE
Catalog search

### DIFF
--- a/resources/common/common_api.robot
+++ b/resources/common/common_api.robot
@@ -401,13 +401,15 @@ Response body parameter should NOT be:
 Response body parameter should have datatype:
     [Documentation]    This keyword checks that the response saved  in ``${response_body}`` test variable contsains the speficied parameter ``${parameter}`` and that parameter has the specified data type ``${expected_data_type}``.
     ...
-    ...    Some types that can be used are: ``int``, ``str``. It uses a custom keyword ``Evaluate datatype of a variable:`` to evaluate the datatype.
+    ...    Some types that can be used are: ``int``, ``str``, ``list``. It uses a custom keyword ``Evaluate datatype of a variable:`` to evaluate the datatype.
     ...
     ...    *Example:*
     ...
     ...    ``Response body parameter should have datatype:    [data][0][attributes][name]    str``
+    ...    ``Response body parameter should have datatype:    [data][0][attributes][sort][sortParamNames]    list``
     [Arguments]    ${parameter}    ${expected_data_type}
-    ${actual_data_type}=    Evaluate datatype of a variable:    ${parameter}
+    @{parameter}=    Get Value From Json    ${response_body}    ${parameter}
+    ${actual_data_type}=    Evaluate datatype of a variable:    @{parameter}
     Should Be Equal    ${actual_data_type}    ${expected_data_type}
 
 Evaluate datatype of a variable:

--- a/resources/common/common_api.robot
+++ b/resources/common/common_api.robot
@@ -433,6 +433,16 @@ Response header parameter should be:
     ${actual_header_value}=    Get From Dictionary    ${response_headers}    ${header_parameter}
     Should Be Equal    ${actual_header_value}    ${header_value}
 
+Response header parameter should contain:
+    [Documentation]    This keyword checks that the response header saved previiously in ``${response_headers}`` test variable has the expected header with name ``${header_parameter}`` and this header contains substring ``${header_value}``
+    ...
+    ...    *Example:*
+    ...
+    ...    ``Response header parameter should be:    Content-Type    ${default_header_content_type}``
+    [Arguments]    ${header_parameter}    ${header_value}
+    ${actual_header_value}=    Get From Dictionary    ${response_headers}    ${header_parameter}
+    Should Contain    ${actual_header_value}    ${header_value}
+
 Response body has correct self link
     [Documentation]    This keyword checks that the actual selflink retrieved from the test variable ``${response_body}`` matches the self link recorded into the ``${expected_self_link}`` test variable on endpoint call.
     ...

--- a/resources/common/common_api.robot
+++ b/resources/common/common_api.robot
@@ -495,9 +495,10 @@ Response body has correct self link for created entity:
     Log    ${response_body}  
     Should Be Equal    ${actual_self_link}    ${expected_self_link}/${url}
 
-
 Response body parameter should not be EMPTY:
     [Documentation]    This keyword checks that the body parameter sent in ``${json_path}`` argument is not empty. If the parameter value is other that ``null`` the keyword will fail.
+    ...
+    ...    This keyword checks both that the parameter does not have null value or that it does not have an empty string value and makes sure that the pagameter actually exists.
     ...
     ...    *Example:*
     ...
@@ -508,7 +509,8 @@ Response body parameter should not be EMPTY:
     ${data}=    Replace String    ${data}    '   ${EMPTY}
     ${data}=    Replace String    ${data}    [   ${EMPTY}
     ${data}=    Replace String    ${data}    ]   ${EMPTY}
-    Should Not Be Equal    ${data}    None    ${data} is not empty but shoud be
+    Should Not Be Empty    ${data}    ${data} is empty but shoud not be
+    Should Not Be Equal    ${data}    None    Propewrty value is ${data} which is null, but it shoud be a non-null value
 
 Response body parameter should be greater than:
     [Documentation]    This keyword checks that the body parameter sent in ``${json_path}`` argument is greater than a specific integer value ``${expected_value}``.
@@ -581,6 +583,25 @@ Response should contain the array larger than a certain size:
     ${result}=    Convert To String    ${result}
     Should Be Equal    ${result}    True    Actual array length is ${list_length} and it is not greater than expected ${expected_size}
     
+Response should contain the array smaller than a certain size:
+    [Documentation]    This keyword checks that the body array sent in ``${json_path}`` argument contains the number of items that is fewer than ``${expected_size}``. 
+    ...    The expected size should be an integer value that is less than you expect elements. So if you expect an array to have 0 or 1 elements, the ``${expected_size}`` should be 2.
+    ...
+    ...    It can be used to check how many elements were returned, if you know the exact number of emelents that should be returned, but know there should be fewer, than the default value for example.
+    ...    It is useful when you check search and know how many values are there if there is no filtering, but you also know that with filtering, there should be fewer values than without it.
+    ...
+    ...    *Example:*
+    ...
+    ...    ``Response should contain the array smaller than a certain size:    [data][0][attributes][valueFacets][1]    5``
+    [Arguments]    ${json_path}    ${expected_size}
+    @{data}=    Get Value From Json    ${response_body}    ${json_path}
+    Log    @{data}
+    ${list_length}=    Get Length    @{data}
+    ${list_length}=    Convert To Integer    ${list_length}
+    ${result}=    Evaluate   ${list_length} < ${expected_size}
+    ${result}=    Convert To String    ${result}
+    Should Be Equal    ${result}    True    Actual array length is ${list_length} and it is not greater than expected ${expected_size}
+
 Each array element of array in response should contain property:
     [Documentation]    This keyword checks whether the array ``${json_path}`` that is present in the ``${response_body}`` test variable contsains a property with ``${expected_property}`` name in every of it's array elements.
     ...
@@ -822,6 +843,23 @@ Response body parameter should contain:
     ${data}=    Replace String    ${data}    ]   ${EMPTY}
     Log    ${data}
     Should Contain   ${data}    ${expected_value}  
+
+Response body parameter should start with:
+    [Documentation]    This keyword checks that response parameter with name ``${json_path}`` starts with the specified substing ``${expected_value}``. 
+    ...
+    ...    *Example:*
+    ...
+    ...    ``Response body parameter should start with:    [data][attributes][name]    Comp``
+    ...
+    ...    The example above checks that ``name`` parameter starts with 'comp', e.g. as in Computer. 
+    [Arguments]    ${json_path}    ${expected_value}
+    ${data}=    Get Value From Json    ${response_body}    ${json_path}
+    ${data}=    Convert To String    ${data}
+    ${data}=    Replace String    ${data}    '   ${EMPTY}
+    ${data}=    Replace String    ${data}    [   ${EMPTY}
+    ${data}=    Replace String    ${data}    ]   ${EMPTY}
+    Log    ${data}
+    Should Start With   ${data}    ${expected_value}  
 
 Array in response should contain property with value:
     [Documentation]    This keyword checks is the specified array (usually error array) ``${json_path} `` contains the specified property name ``${expected_property}`` with the specified value ``${expected_value}``.

--- a/resources/environments/environments_api_b2b.json
+++ b/resources/environments/environments_api_b2b.json
@@ -89,6 +89,7 @@
 
         "concrete_product_with_alternative_sku": "420566",
         "abstract_product_with_alternative_sku": "M21100",
+        "abstract_product_with_alternative_name": "Verbatim USB stick Store n Go V3 49173 32GB USB3.0 gray",
         "alternative_abstract_product": "M21099",
 
         "abstract_available_product_with_stock": "M90799",

--- a/resources/environments/environments_api_b2b.json
+++ b/resources/environments/environments_api_b2b.json
@@ -63,7 +63,10 @@
         "currency_symbol_eur": "€",
         "store_de": "DE",
         "gross_mode": "GROSS_MODE",
-        "net_mode": "NET_MODE"
+        "net_mode": "NET_MODE",
+        "currency_name_chf": "Swiss Franc",
+        "currency_code_chf": "CHF",
+        "currency_symbol_chf": "CHF"
     },
     "search":{
         "total_number_of_products_in_search": "420",
@@ -72,7 +75,9 @@
         "ipp_biggest": "36",
         "default_ipp_pages_qty": "35",
         "default_categories_qty": "37",
+        "default_colors_qty": "10",
         "default_labels_qty": "5",
+        "default_materials_qty": "10",
         "default_brands_qty": "10",
         "default_min_rating": "4",
         "default_max_rating": "5",
@@ -82,9 +87,17 @@
         "sale_label": "SALE %",
         "manual_label": "Top",
         "discontinued_label": "Discontinued",
-        "alternatives_label": "Alternatives available"
+        "alternatives_label": "Alternatives available",
 
+        "category_id_lvl1": "11",
+        "category_items_qty_lvl1": "172",
+        "category_id_lvl2": "12",
+        "category_items_qty_lvl2": "56",
+        "category_id_lvl3": "13",
+        "category_items_qty_lvl3": "28",
+        "category_tree_branches_qty": "6",
 
+        "abstract_sku_highest_rating": "M1016129"
 
     },
         
@@ -161,10 +174,12 @@
     "product_attributes":{
         "brand_1": "Soennecken",
         "brand_2": "edding",
-        "material_aluminum": "aluminum",
-        "material_metal": "metal",
-        "material_chipboard": "chipboard",
-        "color_purple": "purple"
+        "material_1": "aluminum",
+        "material_2": "metal",
+        "material_3": "chipboard",
+        "color_3": "purple",
+        "color_1": "yellow",
+        "color_2": "blue"
     },
     "content":{
 

--- a/resources/environments/environments_api_b2b.json
+++ b/resources/environments/environments_api_b2b.json
@@ -123,6 +123,14 @@
         "abstract_product_with_options_name": "Safescan automatic banknote counter - UV counterfeit recognition"
             
     },
+    "product_attributes":{
+        "brand_1": "Soennecken",
+        "brand_2": "edding",
+        "material_aluminum": "aluminum",
+        "material_metal": "metal",
+        "material_chipboard": "chipboard",
+        "color_purple": "purple"
+    },
     "content":{
 
         "abstract_product_list_id": "apl-1",

--- a/resources/environments/environments_api_b2b.json
+++ b/resources/environments/environments_api_b2b.json
@@ -75,7 +75,16 @@
         "default_labels_qty": "5",
         "default_brands_qty": "10",
         "default_min_rating": "4",
-        "default_max_rating": "5"
+        "default_max_rating": "5",
+        "sorting_options_qty": "5",
+
+        "new_label": "New",
+        "sale_label": "SALE %",
+        "manual_label": "Top",
+        "discontinued_label": "Discontinued",
+        "alternatives_label": "Alternatives available"
+
+
 
     },
         

--- a/resources/environments/environments_api_b2b.json
+++ b/resources/environments/environments_api_b2b.json
@@ -65,6 +65,19 @@
         "gross_mode": "GROSS_MODE",
         "net_mode": "NET_MODE"
     },
+    "search":{
+        "total_number_of_products_in_search": "420",
+        "default_ipp": "12",
+        "ipp_middle": "24",
+        "ipp_biggest": "36",
+        "default_ipp_pages_qty": "35",
+        "default_categories_qty": "37",
+        "default_labels_qty": "5",
+        "default_brands_qty": "10",
+        "default_min_rating": "4",
+        "default_max_rating": "5"
+
+    },
         
     "products": {
         

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/negative.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/negative.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Suite Setup       SuiteSetup
+Resource    ../../../../../../resources/common/common_api.robot
+
+*** Test Cases ***
+
+# bug https://spryker.atlassian.net/browse/CC-15983
+Search_without_query_parameter
+    When I send a GET request:    /catalog-search?q=
+    Then Response status code should be:    400
+    And Response reason should be:    Bad Request
+    And Response should return error message:    q parameter is missing.
+
+
+
+   

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
@@ -84,6 +84,24 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should not be EMPTY:    [links][first]
     And Response body parameter should not be EMPTY:    [links][next]
 
+Search_by_attribute_that_does_not_return_products
+    When I send a GET request:    /catalog-search?q=fake
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
+    #categories
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][0][values]    0
+    #labels
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][1][values]    0
+    #brand
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    0
+    And Response body has correct self link
+
 Search_by_concrete_sku
     When I send a GET request:    /catalog-search?q=${concrete_product_with_alternative_sku}
     Then Response status code should be:    200
@@ -104,6 +122,189 @@ Search_by_concrete_sku
     #brand
     And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    1
     And Response body has correct self link
-    And Response body parameter should not be EMPTY:    [links][last]
-    And Response body parameter should not be EMPTY:    [links][first]
-    And Response body parameter should not be EMPTY:    [links][last]
+
+Search_by_abstract_sku
+    When I send a GET request:    /catalog-search?q=${abstract_product_with_alternative_sku}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    1
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    100
+    #categories
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][0][values]    4
+    #labels
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][1][values]    2
+    #brand
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    1
+    And Response body has correct self link
+
+Search_by_full_name
+    When I send a GET request:    /catalog-search?q=${abstract_product_with_alternative_name}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    12
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    100
+    #categories
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][0][values]    4
+    #labels
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][1][values]    2
+    #brand
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][4][values]    1
+    And Response body has correct self link
+
+Search_by_name_substring
+    When I send a GET request:    /catalog-search?q=USB
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    12
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response body parameter should NOT be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
+    And Response body parameter should NOT be:   [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
+    #categories
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][0][values]    4
+    #labels
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][1][values]    2
+    #brand
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][4][values]    1
+    And Response body has correct self link
+
+Search_by_attribute_(brand)
+    When I send a GET request:    /catalog-search?q=${brand_1}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response body parameter should contain:   [data][0][attributes][abstractProducts][0][abstractName]    ${brand_1}
+    #brand
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    1
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    None
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][values][0][value]    ${brand_1}
+    And Response body has correct self link
+
+Search_by_several_attributes
+    When I send a GET request:    /catalog-search?q=${color_purple}+${material_chipboard}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    20
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+
+Filter_by_rating_only_min
+    When I send a GET request:    /catalog-search?q=&rating[min]=3
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    20
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    #rating facets
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    3
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    5
+
+
+Filter_by_rating_only_max
+    When I send a GET request:    /catalog-search?q=&rating[max]=4
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    #rating facets
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    4
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    4
+
+
+Filter_by_rating_Min_max
+    When I send a GET request:    /catalog-search?q=&rating[min]=3&rating[max]=3
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
+    #rating facets
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    3
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    3
+
+Filter_by_brand_one_brand
+    When I send a GET request:    /catalog-search?q=&brand=${brand_1}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    ${brand_1}
+    And Response body has correct self link
+
+Filter_by_brand_two_brands
+    When I send a GET request:    /catalog-search?q=&brand[]=${brand_2}&brand[]=${brand_1}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    38
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue][0]    ${brand_2}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue][1]    ${brand_1}
+
+Filter_by_brand_empty_brand
+    When I send a GET request:    /catalog-search?q=&brand=
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    420
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    ${EMPTY}
+    And Response body has correct self link
+
+Filter_by_brand_non_existing_brand
+    When I send a GET request:    /catalog-search?q=&brand=test123
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    test123
+    And Response body has correct self link

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
@@ -3,6 +3,9 @@ Suite Setup       SuiteSetup
 Resource    ../../../../../../resources/common/common_api.robot
 
 *** Test Cases ***
+
+##### SEARCH PARAMETERS #####
+
 Search_with_empty_search_criteria_all_default_values_check
     When I send a GET request:    /catalog-search?q=
     Then Response status code should be:    200
@@ -33,7 +36,11 @@ Search_with_empty_search_criteria_all_default_values_check
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    prices
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    images
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractSku
-    #Filters - categoty
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][prices][0][currency][code]    ${currency_code_eur}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][prices][0][currency][symbol]    ${currency_symbol_eur} 
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][prices][0][currency][name]    ${currency_name_eur} 
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    1  
+    #Filters - category
     And Response body parameter should contain:    [data][0][attributes]    valueFacets
     And Response body parameter should be:    [data][0][attributes][valueFacets][0][name]    category
     And Response body parameter should be:    [data][0][attributes][valueFacets][0][localizedName]    Categories
@@ -49,13 +56,13 @@ Search_with_empty_search_criteria_all_default_values_check
     #Filters - color
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][name]    farbe
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][localizedName]    Color
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][2][values]    1
+    And Response should contain the array of acertain size:    [data][0][attributes][valueFacets][2][values]    ${default_colors_qty}
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][config][isMultiValued]    True
     #Filters - material
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][name]    material
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][localizedName]    Material
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][3][values]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][3][values]    ${default_materials_qty}
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][config][isMultiValued]    True
     #Filters - brand
@@ -72,8 +79,8 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    ${default_min_rating}
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    ${default_max_rating}
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][config][isMultiValued]    False
-    #Filters - category
-    And Response should contain the array larger than a certain size:    [data][0][attributes][categoryTreeFilter]    1
+    #Filters - category tree
+    And Response should contain the array of a certain size:    [data][0][attributes][categoryTreeFilter]    ${category_tree_branches_qty}
     And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   nodeId
     And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   name  
     And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   docCount  
@@ -203,7 +210,7 @@ Search_by_attribute_(brand)
     And Response body has correct self link
 
 Search_by_several_attributes
-    When I send a GET request:    /catalog-search?q=${color_purple}+${material_chipboard}
+    When I send a GET request:    /catalog-search?q=${color_3}+${material_3}
     Then Response status code should be:    200
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
@@ -212,6 +219,8 @@ Search_by_several_attributes
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+
+##### FILTERING #####
 
 Filter_by_rating_only_min
     When I send a GET request:    /catalog-search?q=&rating[min]=3
@@ -346,3 +355,359 @@ Filter_by_label_non_existing_label
     And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
     And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue][0]    test123
+
+Filter_by_label_empty_label
+    When I send a GET request:    /catalog-search?q=&label[]=
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    ${default_ipp_pages_qty}
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue][0]    ${EMPTY}
+
+Filter_by_color_one_color
+    When I send a GET request:    /catalog-search?q=&farbe=${color_1}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    4
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    4
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue]    ${color_1}
+    #additional checks that other filers react accordingly and reduce the number of available facets to match facets present for the found products
+    And Response should contain the array smaller than a certain size:   [data][0][attributes][valueFacets][0]    ${default_categories_qty}
+    And Response should contain the array smaller than a certain size:   [data][0][attributes][valueFacets][3]    ${default_materials_qty}
+    And Response should contain the array smaller than a certain size:    [data][0][attributes][valueFacets][4]    ${default_brands_qty}
+    And Response body has correct self link
+
+Filter_by_color_two_colors
+    When I send a GET request:    /catalog-search?q=&farbe[]=${color_1}&farbe[]=${color_2}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    10
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue][0]    ${color_1}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue][1]    ${color_2}
+
+Filter_by_color_non_existing_color
+    When I send a GET request:    /catalog-search?q=&farbe[]=test123
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue][0]    test123
+
+Filter_by_color_empty_color
+    When I send a GET request:    /catalog-search?q=&farbe[]=
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    ${default_ipp_pages_qty}
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue][0]    ${EMPTY}
+
+Filter_by_material_one_material
+    When I send a GET request:    /catalog-search?q=&material=${material_1}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    4
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    4
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue]    ${material_1}
+    #additional checks that other filers react accordingly and reduce the number of available facets to match facets present for the found products
+    And Response should contain the array smaller than a certain size:   [data][0][attributes][valueFacets][0]    ${default_categories_qty}
+    And Response should contain the array smaller than a certain size:   [data][0][attributes][valueFacets][2]    ${default_colors_qty}
+    And Response should contain the array smaller than a certain size:    [data][0][attributes][valueFacets][4]    ${default_brands_qty}
+    And Response body has correct self link
+
+Filter_by_material_two_materails
+    When I send a GET request:    /catalog-search?q=&material[]=${material_1}&material[]=${material_2}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    15
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue][0]    ${material_1}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue][1]    ${material_2}
+
+Filter_by_material_non_existing_materail
+    When I send a GET request:    /catalog-search?q=&material[]=test123
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue][0]    test123
+
+Filter_by_material_empty_material
+    When I send a GET request:    /catalog-search?q=&material[]=
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    ${default_ipp_pages_qty}
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue][0]    ${EMPTY}
+
+Filter_by_valid_main_category
+    When I send a GET request:    /catalog-search?q=&category=${category_id_lvl1}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${category_items_qty_lvl1}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][activeValue]    ${category_id_lvl1}
+    # check that category tree is correctly updated
+    And Response should contain the array of a certain size:    [data][0][attributes][categoryTreeFilter]    ${category_tree_branches_qty}
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][0][docCount]    0
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][docCount]    ${category_items_qty_lvl1}  
+    And Response body parameter should be greater than:    [data][0][attributes][categoryTreeFilter][3][children][0][docCount]    0  
+    And Response body parameter should be greater than:    [data][0][attributes][categoryTreeFilter][3][children][1][docCount]    0   
+    And Response body parameter should be greater than:    [data][0][attributes][categoryTreeFilter][3][children][0][children][0][docCount]    0  
+    And Response body has correct self link
+
+Filter_by_valid_subcategory
+    When I send a GET request:    /catalog-search?q=&category=${category_id_lvl2}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${category_items_qty_lvl2}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][activeValue]    ${category_id_lvl2}
+    # check that category tree is correctly updated
+    And Response should contain the array of a certain size:    [data][0][attributes][categoryTreeFilter]    ${category_tree_branches_qty}
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][0][docCount]    0
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][docCount]    ${category_items_qty_lvl2}  
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][children][0][docCount]    ${category_items_qty_lvl2}  
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][children][1][docCount]    0   
+    And Response body parameter should be greater than:    [data][0][attributes][categoryTreeFilter][3][children][0][children][0][docCount]    0  
+    And Response body parameter should be less than:    [data][0][attributes][categoryTreeFilter][3][children][0][children][0][docCount]    ${category_items_qty_lvl2} 
+    And Response body has correct self link
+
+Filter_by_valid_sub_subcategory
+    When I send a GET request:    /catalog-search?q=&category=${category_id_lvl3}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${category_items_qty_lvl3}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][activeValue]    ${category_id_lvl3}
+    # check that category tree is correctly updated
+    And Response should contain the array of a certain size:    [data][0][attributes][categoryTreeFilter]    ${category_tree_branches_qty}
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][0][docCount]    0
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][docCount]    ${category_items_qty_lvl3}  
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][children][0][docCount]    ${category_items_qty_lvl3}  
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][children][1][docCount]    0   
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][children][0][children][0][docCount]    ${category_items_qty_lvl3} 
+    And Response body parameter should be:    [data][0][attributes][categoryTreeFilter][3][children][0][children][1][docCount]    0
+    And Response body has correct self link
+
+Search_with_specific_currency
+    When I send a GET request:    /catalog-search?q=&currency=${currency_code_chf}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be less than:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][prices][0][currency][code]    ${currency_code_chf}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][prices][0][currency][symbol]    ${currency_symbol_chf} 
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][prices][0][currency][name]    ${currency_name_chf} 
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    1   
+    And Response body has correct self link
+
+##### PAGINATION AND SORTING #####
+
+Search_set_specific_page_with_default_ipp
+    # here page 4 is selected using offset because 36/12=3 full pages, search shows the next page after the offset
+    When I send a GET request:    /catalog-search?q=&page[limit]=${default_ipp}&page[offset]=36
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    4
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    ${default_ipp_pages_qty}
+    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    ${default_ipp}
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should not be EMPTY:    [links][self]
+    And Response body parameter should not be EMPTY:    [links][last]
+    And Response body parameter should not be EMPTY:    [links][first]
+    And Response body parameter should not be EMPTY:    [links][prev]
+    And Response body parameter should not be EMPTY:    [links][next]
+
+
+Search_set_specific_page_and_nondefault_ipp
+    When I send a GET request:    /catalog-search?q=&page[limit]=${ipp_middle}&page[offset]=36
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    2
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    18
+    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    ${default_ipp}
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${ipp_middle}
+    And Response body parameter should not be EMPTY:    [links][self]
+    And Response body parameter should not be EMPTY:    [links][last]
+    And Response body parameter should not be EMPTY:    [links][first]
+    And Response body parameter should not be EMPTY:    [links][prev]
+    And Response body parameter should not be EMPTY:    [links][next]
+
+Search_set_last_page_and_nondefault_ipp
+    When I send a GET request:    /catalog-search?q=&page[limit]=${ipp_biggest}&page[offset]=${total_number_of_products_in_search}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    12
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    12
+    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    ${default_ipp}
+    And Response should contain the array larger than a certain size:    [data][0][attributes][abstractProducts]    1
+    And Response body parameter should not be EMPTY:    [links][self]
+    And Response body parameter should not be EMPTY:    [links][last]
+    And Response body parameter should not be EMPTY:    [links][first]
+    And Response body parameter should not be EMPTY:    [links][prev]
+
+Search_set_invalid_ipp
+    When I send a GET request:    /catalog-search?q=&page[limit]=18&page[offset]=1
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    ${default_ipp_pages_qty}
+    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    ${default_ipp}
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should not be EMPTY:    [links][self]
+    And Response body parameter should not be EMPTY:    [links][last]
+    And Response body parameter should not be EMPTY:    [links][first]
+    And Response body parameter should not be EMPTY:    [links][next]
+
+Search_sort_by_name_asc
+    When I send a GET request:    /catalog-search?q=&sort=name_asc
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortParam]    name_asc
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortOrder]    asc
+    And Response body parameter should start with:    [data][0][attributes][abstractProducts][0][abstractName]    A
+    And Response body has correct self link
+
+Search_sort_by_name_desc
+    When I send a GET request:    /catalog-search?q=&sort=name_desc
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortParam]    name_desc
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortOrder]    desc
+    And Response body parameter should start with:    [data][0][attributes][abstractProducts][0][abstractName]    r
+    And Response body has correct self link
+
+Search_sort_by_rating
+    When I send a GET request:    /catalog-search?q=&sort=rating
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortParam]    rating
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortOrder]    desc
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_sku_highest_rating}
+    And Response body has correct self link
+
+
+Search_sort_by_price_asc
+    When I send a GET request:    /catalog-search?q=&sort=price_asc
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortParam]    price_asc
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortOrder]    asc
+    And Response body parameter should be less than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    50
+    And Response body has correct self link
+
+Search_sort_by_price_desc
+    When I send a GET request:    /catalog-search?q=&sort=price_desc
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortParam]    price_desc
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortOrder]    desc
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    10000
+    And Response body has correct self link
+
+Search_sort_by_price_filter_query_parameter_and_pagination
+    When I send a GET request:    /catalog-search?q=soe&sort=price_desc&brand=${brand_1}&page[limit]=${ipp_middle}&page[offset]=1
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortParam]    price_desc
+    And Response body parameter should be:    [data][0][attributes][sort][currentSortOrder]    desc
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    18
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    ${brand_1}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    5000
+
+Search_by_abstract_sku_with_abstract_include
+    When I send a GET request:    /catalog-search?q=${abstract_product_with_alternative_sku}&include=abstract-products
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    1
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
+    And Response should contain the array of a certain size:    [data][0][relationships][abstract-products][data]    1
+    And Response should contain the array of a certain size:    [included]    1
+    And Response include should contain certain entity type:    abstract-products
+    And Response include element has self link:   abstract-products
+    And Response body parameter should be:    [included][0][id]  ${abstract_product_with_alternative_sku}
+    And Response body has correct self link

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
@@ -1,0 +1,86 @@
+*** Settings ***
+Suite Setup       SuiteSetup
+Resource    ../../../../../../resources/common/common_api.robot
+
+*** Test Cases ***
+Search_with_empty_search_criteria_all_default_values_check
+    When I send a GET request:    /catalog-search?q=
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][spellingSuggestion]    None
+    #Sorting
+    And Response should contain the array of a certain size:    [data][0][attributes][sort][sortParamNames]    5
+    And Response should contain the array of a certain size:    [data][0][attributes][sort][sortParamLocalizedNames]    5
+    And Response body parameter should contain:    [data][0][attributes]    currentSortParam
+    And Response body parameter should contain:    [data][0][attributes]    currentSortOrder
+    #Pagination
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    420
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    35
+    And Response body parameter should be:    [data][0][attributes][pagination][currentItemsPerPage]    12
+    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    3
+    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    12
+    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    24
+    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    36
+    #Abstract products
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractSku
+    And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    price
+    And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractName
+    And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    prices
+    And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    images
+    And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractSku
+    #Filters - categoty
+    And Response body parameter should contain:    [data][0][attributes]    valueFacets
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][name]    category
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][localizedName]    Categories
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][0][values]    36
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][activeValue]    None
+    And Response body parameter should be:    [data][0][attributes][valueFacets][0][config][isMultiValued]    False
+    #Filters - labels
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][name]    label
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][localizedName]    Product Labels
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][1][values]    4
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue]    None
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][config][isMultiValued]    True
+    #Filters - color
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][name]    farbe
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][localizedName]    Color
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][2][values]    9
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue]    None
+    And Response body parameter should be:    [data][0][attributes][valueFacets][2][config][isMultiValued]    True
+    #Filters - color
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][name]    material
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][localizedName]    Material
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][3][values]    9
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue]    None
+    And Response body parameter should be:    [data][0][attributes][valueFacets][3][config][isMultiValued]    True
+    #Filters - brand
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][name]    brand
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][localizedName]    Brand
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][4][values]    9
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    None
+    And Response body parameter should be:    [data][0][attributes][valueFacets][4][config][isMultiValued]    False
+    #Filters - rating
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][name]    rating
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][localizedName]    Product Ratings
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][min]    4
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][max]    5
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    4
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    5
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][config][isMultiValued]    False
+    #Filters - category
+    And Response should contain the array larger than a certain size:    [data][0][attributes][categoryTreeFilter]    5
+    And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   nodeId
+    And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   name  
+    And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   docCount  
+    And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   children  
+    #Selflinks
+    And Response body has correct self link
+    And Response body parameter should not be EMPTY:    [links][last]
+    And Response body parameter should not be EMPTY:    [links][first]
+    And Response body parameter should not be EMPTY:    [links][next]
+

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
@@ -84,3 +84,26 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should not be EMPTY:    [links][first]
     And Response body parameter should not be EMPTY:    [links][next]
 
+Search_by_concrete_sku
+    When I send a GET request:    /catalog-search?q=${concrete_product_with_alternative_sku}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    1
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
+    And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    100
+    #categories
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][0][values]    4
+    #labels
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][1][values]    2
+    #brand
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    1
+    And Response body has correct self link
+    And Response body parameter should not be EMPTY:    [links][last]
+    And Response body parameter should not be EMPTY:    [links][first]
+    And Response body parameter should not be EMPTY:    [links][last]

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
@@ -11,8 +11,8 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should be:    [data][0][type]    catalog-search
     And Response body parameter should be:    [data][0][attributes][spellingSuggestion]    None
     #Sorting
-    And Response should contain the array of a certain size:    [data][0][attributes][sort][sortParamNames]    5
-    And Response should contain the array of a certain size:    [data][0][attributes][sort][sortParamLocalizedNames]    5
+    And Response should contain the array of a certain size:    [data][0][attributes][sort][sortParamNames]    ${sorting_options_qty}
+    And Response should contain the array of a certain size:    [data][0][attributes][sort][sortParamLocalizedNames]    ${sorting_options_qty}
     And Response body parameter should contain:    [data][0][attributes]    currentSortParam
     And Response body parameter should contain:    [data][0][attributes]    currentSortOrder
     #Pagination
@@ -23,8 +23,8 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    ${default_ipp}
     And Response should contain the array of a certain size:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    3
     And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    ${default_ipp}
-    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    24
-    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    36
+    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    ${ipp_middle}
+    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    ${ipp_biggest}
     #Abstract products
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractSku
@@ -52,7 +52,7 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][2][values]    1
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][config][isMultiValued]    True
-    #Filters - color
+    #Filters - material
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][name]    material
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][localizedName]    Material
     And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][3][values]    1
@@ -61,7 +61,7 @@ Search_with_empty_search_criteria_all_default_values_check
     #Filters - brand
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][name]    brand
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][localizedName]    Brand
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][4][values]    ${default_brands_qty}
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    ${default_brands_qty}
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][config][isMultiValued]    False
     #Filters - rating
@@ -308,3 +308,41 @@ Filter_by_brand_non_existing_brand
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    test123
     And Response body has correct self link
+
+Filter_by_label_one_label
+    When I send a GET request:    /catalog-search?q=&label=${manual_label}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    5
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    5
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue]    ${manual_label}
+    And Response body has correct self link
+
+Filter_by_label_two_labels
+    When I send a GET request:    /catalog-search?q=&label[]=${new_label}&label[]=${manual_label}
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    39
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue][0]    ${new_label}
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue][1]    ${manual_label}
+
+Filter_by_label_non_existing_label
+    When I send a GET request:    /catalog-search?q=&label[]=test123
+    Then Response status code should be:    200
+    And Response reason should be:    OK
+    And Response header parameter should be:    Content-Type    ${default_header_content_type}
+    And Response body parameter should be:    [data][0][type]    catalog-search
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    0
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    0
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    0
+    And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue][0]    test123

--- a/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search/positive.robot
@@ -16,17 +16,17 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should contain:    [data][0][attributes]    currentSortParam
     And Response body parameter should contain:    [data][0][attributes]    currentSortOrder
     #Pagination
-    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    420
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
-    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    35
-    And Response body parameter should be:    [data][0][attributes][pagination][currentItemsPerPage]    12
-    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    12
+    And Response body parameter should be:    [data][0][attributes][pagination][maxPage]    ${default_ipp_pages_qty}
+    And Response body parameter should be:    [data][0][attributes][pagination][currentItemsPerPage]    ${default_ipp}
+    And Response body parameter should be:    [data][0][attributes][pagination][config][defaultItemsPerPage]    ${default_ipp}
     And Response should contain the array of a certain size:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    3
-    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    12
+    And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    ${default_ipp}
     And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    24
     And Response body parameter should contain:    [data][0][attributes][pagination][config][validItemsPerPageOptions]    36
     #Abstract products
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractSku
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    price
     And Each array element of array in response should contain value:    [data][0][attributes][abstractProducts]    abstractName
@@ -37,43 +37,43 @@ Search_with_empty_search_criteria_all_default_values_check
     And Response body parameter should contain:    [data][0][attributes]    valueFacets
     And Response body parameter should be:    [data][0][attributes][valueFacets][0][name]    category
     And Response body parameter should be:    [data][0][attributes][valueFacets][0][localizedName]    Categories
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][0][values]    36
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][0][values]    ${default_categories_qty}
     And Response body parameter should be:    [data][0][attributes][valueFacets][0][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][0][config][isMultiValued]    False
     #Filters - labels
     And Response body parameter should be:    [data][0][attributes][valueFacets][1][name]    label
     And Response body parameter should be:    [data][0][attributes][valueFacets][1][localizedName]    Product Labels
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][1][values]    4
+    And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][1][values]    ${default_labels_qty}
     And Response body parameter should be:    [data][0][attributes][valueFacets][1][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][1][config][isMultiValued]    True
     #Filters - color
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][name]    farbe
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][localizedName]    Color
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][2][values]    9
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][2][values]    1
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][2][config][isMultiValued]    True
     #Filters - color
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][name]    material
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][localizedName]    Material
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][3][values]    9
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][3][values]    1
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][3][config][isMultiValued]    True
     #Filters - brand
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][name]    brand
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][localizedName]    Brand
-    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][4][values]    9
+    And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][4][values]    ${default_brands_qty}
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    None
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][config][isMultiValued]    False
     #Filters - rating
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][name]    rating
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][localizedName]    Product Ratings
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][min]    4
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][max]    5
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    4
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    5
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][min]    ${default_min_rating}
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][max]    ${default_max_rating}
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    ${default_min_rating}
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    ${default_max_rating}
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][config][isMultiValued]    False
     #Filters - category
-    And Response should contain the array larger than a certain size:    [data][0][attributes][categoryTreeFilter]    5
+    And Response should contain the array larger than a certain size:    [data][0][attributes][categoryTreeFilter]    1
     And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   nodeId
     And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   name  
     And Each array element of array in response should contain value:    [data][0][attributes][categoryTreeFilter]   docCount  
@@ -114,7 +114,7 @@ Search_by_concrete_sku
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    1
     And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
     And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
-    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    100
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    10
     #categories
     And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][0][values]    4
     #labels
@@ -135,7 +135,7 @@ Search_by_abstract_sku
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    1
     And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
     And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
-    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    100
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    10
     #categories
     And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][0][values]    4
     #labels
@@ -150,13 +150,13 @@ Search_by_full_name
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
     And Response body parameter should be:    [data][0][type]    catalog-search
-    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    12
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    ${default_ipp}
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
     And Response body parameter should be:    [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
-    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    100
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][prices][0][DEFAULT]    10
     #categories
     And Response should contain the array larger than a certain size:    [data][0][attributes][valueFacets][0][values]    4
     #labels
@@ -171,10 +171,10 @@ Search_by_name_substring
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
     And Response body parameter should be:    [data][0][type]    catalog-search
-    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    12
+    And Response body parameter should be greater than:    [data][0][attributes][pagination][numFound]    ${default_ipp}
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Response body parameter should NOT be:    [data][0][attributes][abstractProducts][0][abstractSku]    ${abstract_product_with_alternative_sku}
     And Response body parameter should NOT be:   [data][0][attributes][abstractProducts][0][abstractName]    ${abstract_product_with_alternative_name}
     #categories
@@ -194,7 +194,7 @@ Search_by_attribute_(brand)
     And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Response body parameter should contain:   [data][0][attributes][abstractProducts][0][abstractName]    ${brand_1}
     #brand
     And Response should contain the array of a certain size:    [data][0][attributes][valueFacets][4][values]    1
@@ -211,7 +211,7 @@ Search_by_several_attributes
     And Response body parameter should be:    [data][0][attributes][pagination][numFound]    20
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
 
 Filter_by_rating_only_min
     When I send a GET request:    /catalog-search?q=&rating[min]=3
@@ -222,14 +222,14 @@ Filter_by_rating_only_min
     And Response body parameter should be:    [data][0][attributes][pagination][numFound]    20
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     #rating facets
     And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    3
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    5
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    ${default_max_rating}
 
 
 Filter_by_rating_only_max
-    When I send a GET request:    /catalog-search?q=&rating[max]=4
+    When I send a GET request:    /catalog-search?q=&rating[max]=${default_min_rating}
     Then Response status code should be:    200
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
@@ -237,10 +237,10 @@ Filter_by_rating_only_max
     And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     #rating facets
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    4
-    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    4
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMin]    ${default_min_rating}
+    And Response body parameter should be:    [data][0][attributes][rangeFacets][0][activeMax]    ${default_min_rating}
 
 
 Filter_by_rating_Min_max
@@ -266,7 +266,7 @@ Filter_by_brand_one_brand
     And Response body parameter should be:    [data][0][attributes][pagination][numFound]    18
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    ${brand_1}
     And Response body has correct self link
 
@@ -279,7 +279,7 @@ Filter_by_brand_two_brands
     And Response body parameter should be:    [data][0][attributes][pagination][numFound]    38
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue][0]    ${brand_2}
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue][1]    ${brand_1}
 
@@ -289,10 +289,10 @@ Filter_by_brand_empty_brand
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
     And Response body parameter should be:    [data][0][type]    catalog-search
-    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    420
+    And Response body parameter should be:    [data][0][attributes][pagination][numFound]    ${total_number_of_products_in_search}
     And Response body parameter should be:    [data][0][attributes][pagination][currentPage]    1
     And Response body parameter should be greater than:    [data][0][attributes][pagination][maxPage]    1
-    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    12
+    And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    ${default_ipp}
     And Response body parameter should be:    [data][0][attributes][valueFacets][4][activeValue]    ${EMPTY}
     And Response body has correct self link
 


### PR DESCRIPTION
added /catalog-search tests
also 

- added a few new keywords
- fixed `Response body parameter should have datatype:` - did not detect type correctly before
- fixed `Response body parameter should not be EMPTY:` - did not detect cases when parameter was missing completely and confirmed that it was not empty when it was not even there

