### PR TITLE
smoke-b2c-order-cancelation

### DIFF
--- a/resources/environments/environments_b2c.json
+++ b/resources/environments/environments_b2c.json
@@ -25,7 +25,7 @@
         "one_variant_product_abstract_sku": "009",
         "one_variant_product_abstract_name": "EUROKRAFT trolley - with open shovel",
         "one_variant_product_default_price": "€99.99",
-        
+        "one_variant_product_concrete_sku": "009_30692991",
         "bundle_product_abstract_sku": "211",
         "bundle_product_product_name": "HP Bundle",
         "bundled_product_1_abstract_sku": "121",

--- a/resources/pages/yves/yves_order_details_page.robot
+++ b/resources/pages/yves/yves_order_details_page.robot
@@ -3,3 +3,4 @@ ${order_details_main_content_locator}    xpath=//customer-reorder-form[@data-qa=
 ${order_details_reorder_all_button}    xpath=//customer-reorder-form[@data-qa='component customer-reorder-form']//button[contains(.,'Reorder all')]
 ${order_details_reorder_selected_items_button}    xpath=//customer-reorder-form[@data-qa='component customer-reorder-form']//button[contains(.,'Reorder selected items')]
 ${order_details_shipping_address_locator}    xpath=//div[@class='summary-sidebar__item']//ul[@data-qa='component display-address']
+${order_details_cancel_button_locator}    xpath= //remote-form-submit[contains(@form-action,'cancel')]//button

--- a/resources/pages/yves/yves_order_history_page.robot
+++ b/resources/pages/yves/yves_order_history_page.robot
@@ -1,3 +1,2 @@
 *** Variables ***
 ${order_history_main_content_locator}    xpath=//div[contains(@data-qa,'component order-table')]
-${order_cancel_button_locator}    xpath=//button[contains(@class,'button--hollow-alert')]

--- a/resources/pages/yves/yves_order_history_page.robot
+++ b/resources/pages/yves/yves_order_history_page.robot
@@ -1,2 +1,3 @@
 *** Variables ***
 ${order_history_main_content_locator}    xpath=//div[contains(@data-qa,'component order-table')]
+${order_cancel_button_locator}    xpath=//button[contains(@class,'button--hollow-alert')]

--- a/resources/steps/order_history_steps.robot
+++ b/resources/steps/order_history_steps.robot
@@ -51,5 +51,8 @@ Yves: 'Order History' page contains the following order with a status:
 
 Yves: 'Order Details' page contains the cancel order button:
     [Arguments]    ${condition}
-    IF    '${condition}' == 'True'    Element Should Be Visible    ${order_cancel_button_locator}
-    IF    '${condition}' == 'False'    Element Should Not Be Visible    ${order_cancel_button_locator} 
+    IF    '${condition}' == 'true'    
+        Element Should Be Visible    ${order_details_cancel_button_locator}
+    ELSE
+        Element Should Not Be Visible    ${order_details_cancel_button_locator}
+    END    

--- a/resources/steps/order_history_steps.robot
+++ b/resources/steps/order_history_steps.robot
@@ -48,3 +48,8 @@ Yves: 'Order History' page contains the following order with a status:
     [Arguments]    ${orderID}    ${expectedStatus}
     ${actualOrderStatus}=    Get Text    xpath=//div[contains(@data-qa,'component order-table')]//td[text()='${orderID}']/..//span[@data-qa='component status']
     Should Be Equal    ${actualOrderStatus}    ${expectedStatus}    msg=None    values=True    ignore_case=True    formatter=str
+
+Yves: 'Order Details' page contains the cancel order button:
+    [Arguments]    ${condition}
+    IF    '${condition}' == 'True'    Element Should Be Visible    ${order_cancel_button_locator}
+    IF    '${condition}' == 'False'    Element Should Not Be Visible    ${order_cancel_button_locator} 

--- a/resources/steps/orders_management_steps.robot
+++ b/resources/steps/orders_management_steps.robot
@@ -156,6 +156,6 @@ Zed: order has the following number of shipments:
 Yves: cancel the order:
     [Arguments]    ${order_id}
     Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${order_id}
-    Click    ${order_cancel_button_locator}
+    Click    ${order_details_cancel_button_locator}
     Yves: go to 'Order History' page
     Yves: 'Order History' page contains the following order with a status:    ${order_id}    Canceled

--- a/resources/steps/orders_management_steps.robot
+++ b/resources/steps/orders_management_steps.robot
@@ -5,6 +5,7 @@ Resource    ../pages/yves/yves_return_slip_page.robot
 Resource    ../pages/zed/zed_create_return_page.robot
 Resource    ../pages/zed/zed_return_details_page.robot
 Resource    ../steps/order_history_steps.robot
+Resource    ../pages/yves/yves_order_details_page.robot
 
 *** Keywords ***
 Zed: go to order page:
@@ -151,3 +152,10 @@ Zed: order has the following number of shipments:
     Wait Until Element Is Visible    xpath=//table[@data-qa='order-item-list'][1]
     ${actualShipments}=    Get Element Count    xpath=//table[@data-qa='order-item-list']
     Should Be Equal    '${expectedShipments}'    '${actualShipments}'
+
+Yves: cancel the order:
+    [Arguments]    ${order_id}
+    Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${order_id}
+    Click    ${order_cancel_button_locator}
+    Yves: go to 'Order History' page
+    Yves: 'Order History' page contains the following order with a status:    ${order_id}    Canceled

--- a/tests/smoke/smoke_b2c.robot
+++ b/tests/smoke/smoke_b2c.robot
@@ -671,3 +671,64 @@ Add_to_cart_products_as_a_guest_user_and_register_during_checkout
      [Teardown]    Zed: delete customer:
     ...    || email                          ||
     ...    || abc${random}@gmail.com ||
+
+Order_cancelation
+    [Documentation]    Cancel  order within a time period
+    Yves: login on Yves with provided credentials:    ${yves_second_user_email}
+    Yves: go to PDP of the product with sku:    ${one_variant_product_abstract_sku}
+    Yves: add product to the shopping cart
+    Yves: go to b2c shopping cart
+    Yves: click on the 'Checkout' button in the shopping cart
+    Yves: billing address same as shipping address:    true
+    Yves: fill in the following new shipping address:
+    ...    || salutation | firstName                      | lastName                      | street        | houseNumber | postCode | city   | country | company | phone     | additionalAddress ||
+    ...    || Mr.        | ${yves_second_user_first_name} | ${yves_second_user_last_name} | Kirncher Str. | 7           | 10247    | Berlin | Germany | Spryker | 123456789 | Additional street ||
+    Yves: submit form on the checkout
+    Yves: select the following shipping method on the checkout and go next:    Express
+    Yves: select the following payment method on the checkout and go next:    Invoice
+    Yves: accept the terms and conditions:    true
+    Yves: 'submit the order' on the summary page
+    Yves: 'Thank you' page is displayed    
+    Yves: go to 'Order History' page
+    Yves: get the last placed order ID by current customer
+    Yves: cancel the order:    ${lastPlacedOrder}
+    
+Order_cancelation_after_time_skipout
+    Yves: login on Yves with provided credentials:    ${yves_second_user_email}
+    Yves: go to PDP of the product with sku:    ${one_variant_product_abstract_sku}
+    Yves: add product to the shopping cart
+    Yves: go to PDP of the product with sku:    ${bundled_product_1_concrete_sku}
+    Yves: add product to the shopping cart
+    Yves: go to b2c shopping cart
+    Yves: shopping cart contains the following products:    ${one_variant_product_abstract_sku}    ${bundled_product_1_concrete_sku}
+    Yves: click on the 'Checkout' button in the shopping cart
+    Yves: billing address same as shipping address:    true
+    Yves: fill in the following new shipping address:
+    ...    || salutation | firstName                      | lastName                      | street        | houseNumber | postCode | city   | country | company | phone     | additionalAddress ||
+    ...    || Mr.        | ${yves_second_user_first_name} | ${yves_second_user_last_name} | Kirncher Str. | 7           | 10247    | Berlin | Germany | Spryker | 123456789 | Additional street ||
+    Yves: submit form on the checkout
+    Yves: select the following shipping method on the checkout and go next:    Express
+    Yves: select the following payment method on the checkout and go next:    Invoice
+    Yves: 'submit the order' on the summary page
+    Yves: accept the terms and conditions:    true
+    Yves: 'Thank you' page is displayed    
+    Yves: go to 'Order History' page
+    Yves: get the last placed order ID by current customer
+    #change the order state of one product 
+    Zed: login on Zed with provided credentials:    ${zed_admin_email}
+    Zed: go to order page:    ${lastPlacedOrder}
+    Zed: trigger matching state of order item inside xxx shipment:    ${one_variant_product_concrete_sku}    Pay
+    Zed: trigger matching state of order item inside xxx shipment:    ${one_variant_product_concrete_sku}    Skip timeout 
+    Yves: login on Yves with provided credentials:    ${yves_second_user_email}
+    Yves: go to URL:    /en/customer/order
+    Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${lastPlacedOrder}
+    Yves: 'Order Details' page contains the cancel order button:    False
+    #change state of state of all products 
+    Zed: login on Zed with provided credentials:    ${zed_admin_email}
+    Zed: go to order page:    ${lastPlacedOrder}
+    Zed: trigger matching state of order item inside xxx shipment:    ${bundled_product_1_concrete_sku}    Pay
+    Zed: trigger matching state of order item inside xxx shipment:    ${bundled_product_1_concrete_sku}    Skip timeout
+    Yves: login on Yves with provided credentials:    ${yves_second_user_email}
+    Yves: go to URL:    /en/customer/order
+    Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${lastPlacedOrder}
+    Yves: 'Order Details' page contains the cancel order button:    False

--- a/tests/smoke/smoke_b2c.robot
+++ b/tests/smoke/smoke_b2c.robot
@@ -693,7 +693,8 @@ Order_cancelation
     Yves: get the last placed order ID by current customer
     Yves: cancel the order:    ${lastPlacedOrder}
     
-Order_cancelation_after_time_skipout
+Order_cancelation
+    [Documentation]    Check cancel order functionality in yves after trigger order states in zed
     Yves: login on Yves with provided credentials:    ${yves_second_user_email}
     Yves: go to PDP of the product with sku:    ${one_variant_product_abstract_sku}
     Yves: add product to the shopping cart
@@ -718,17 +719,23 @@ Order_cancelation_after_time_skipout
     Zed: login on Zed with provided credentials:    ${zed_admin_email}
     Zed: go to order page:    ${lastPlacedOrder}
     Zed: trigger matching state of order item inside xxx shipment:    ${one_variant_product_concrete_sku}    Pay
+    Yves: login on Yves with provided credentials:    ${yves_second_user_email}
+    Yves: go to URL:    /customer/order
+    Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${lastPlacedOrder}
+    Yves: 'Order Details' page contains the cancel order button:    true
+    Zed: login on Zed with provided credentials:    ${zed_admin_email}
+    Zed: go to order page:    ${lastPlacedOrder}
     Zed: trigger matching state of order item inside xxx shipment:    ${one_variant_product_concrete_sku}    Skip timeout 
     Yves: login on Yves with provided credentials:    ${yves_second_user_email}
-    Yves: go to URL:    /en/customer/order
+    Yves: go to URL:    /customer/order
     Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${lastPlacedOrder}
-    Yves: 'Order Details' page contains the cancel order button:    False
+    Yves: 'Order Details' page contains the cancel order button:    false
     #change state of state of all products 
     Zed: login on Zed with provided credentials:    ${zed_admin_email}
     Zed: go to order page:    ${lastPlacedOrder}
     Zed: trigger matching state of order item inside xxx shipment:    ${bundled_product_1_concrete_sku}    Pay
     Zed: trigger matching state of order item inside xxx shipment:    ${bundled_product_1_concrete_sku}    Skip timeout
     Yves: login on Yves with provided credentials:    ${yves_second_user_email}
-    Yves: go to URL:    /en/customer/order
+    Yves: go to URL:    /customer/order
     Yves: 'View Order/Reorder/Return' on the order history page:    View Order    ${lastPlacedOrder}
-    Yves: 'Order Details' page contains the cancel order button:    False
+    Yves: 'Order Details' page contains the cancel order button:    false


### PR DESCRIPTION
## PR Description
https://spryker.atlassian.net/browse/CC-21837
**Order Cancelation**

-    Customer is able to create a cancellation for an order for own orders within a time period→ As logged in user create an order, then cancel it from user account 
- User can cancel the order while it is in one of the following statuses: payment pending, paid, confirmed only → user should not be able to cancel the order if at least one item is not in the appropriate status.
- User can not cancel an order after the time out for this action passes.