### PR TITLE
b2b-smoke-alternative-products-and-discontinued-products

### DIFF
--- a/resources/environments/environments_b2b.json
+++ b/resources/environments/environments_b2b.json
@@ -81,6 +81,10 @@
 
             "bundled_product_1_concrete_sku": "104939",
             "bundled_product_2_concrete_sku": "574995",
-            "bundled_product_3_concrete_sku": "426581"
+            "bundled_product_3_concrete_sku": "426581",
+
+            "available_product_abstract_sku":  "potato-1",
+            "available_product_concrete_sku":  "potato-1-1"
         }
+
 }

--- a/resources/pages/zed/zed_edit_product_page.robot
+++ b/resources/pages/zed/zed_edit_product_page.robot
@@ -7,3 +7,6 @@ ${zed_pdp_alternative_products_suggestion}    xpath=//ul[@id='select2-product_co
 ${zed_pdp_restore_button}    xpath=//form[@name='product_concrete_form_edit']//div[@id='tab-content-discontinue']//a[contains(@href,'restore')]
 ${zed_dpd_save_button}    xpath=//input[@type='submit' and @value='Save']
 ${zed_product_variant_table_processing_locator}    xpath=//div[@id='product-variant-table_processing']
+${alert_message}    xpath=//p[@class="text-alert"]
+${alternative_for_section}    xpath=//h2[@class="product-alternative-slider__title title title--h4"]
+${replacement_for_section}    xpath=//h2[@class="product-replacement__title title title--h4"]

--- a/resources/steps/products_steps.robot
+++ b/resources/steps/products_steps.robot
@@ -62,3 +62,29 @@ Zed: product is successfully discontinued
     ${currentURL}=    Get Location
     IF    'discontinue' not in '${currentURL}'    Zed: switch to the tab on 'Edit product' page:    Discontinue
     Page Should Contain Element    ${zed_pdp_restore_button}
+
+Yves: check product status:
+    [Documentation]    can be alternative or discontinued
+    [Arguments]    ${status}   
+    Try reloading page until element is/not appear:    //h1[@class="page-info__title title title--h3"]/label-group//span/span[contains(@class,'${status}')]    true
+    Wait Until Element Is Visible    //h1[@class="page-info__title title title--h3"]/label-group//span/span[contains(@class,'${status}')]
+
+Zed: remove alternative product from the concrete:
+    [Arguments]    ${productAbstract}    ${productConcrete}    ${abstractRemoveSku}
+    Wait Until Element Is Visible    ${zed_log_out_button}
+    Zed: go to second navigation item level:    Catalog    Products
+    Zed: perform search by:    ${productAbstract}
+    Zed: click Action Button in a table for row that contains:    ${productAbstract}    Edit
+    Zed: switch to the tab on 'Edit product' page:    Variants
+    Zed: click Action Button in Variant table for row that contains:    ${productConcrete}    Edit
+    Zed: switch to the tab on 'Edit product' page:    Product Alternatives
+    Click    //td[contains(text(),'${abstractRemoveSku}')]//parent::tr//td//a[contains(@class,"btn-danger")]
+
+Yves: check product section:
+    [Arguments]    ${alternative_products}
+    IF    '${alternative_products}' == 'alternative'    Element Should Be Visible    ${alternative_for_section}
+    IF    '${alternative_products}' == 'replacement'    Element Should Be Visible    ${replacement_for_section}
+
+Yves: check product not available on pdp
+    Wait Until Element Is Visible    ${alert_message}
+    Page Should Contain Element    ${alert_message}

--- a/tests/smoke/smoke_b2b.robot
+++ b/tests/smoke/smoke_b2b.robot
@@ -191,20 +191,49 @@ Volume_Prices
 
 Discontinued_Alternative_Products
     [Documentation]    Checks that product can be discontinued in Zed
-    #Todo: extend methods "Zed: discontinue the following product:" and "Zed: undo discontinue the following product:" to check first that the product can be discontinued or undicontinued
-    Yves: go to PDP of the product with sku:  M21100
-    Yves: PDP contains/doesn't contain:    true    ${alternativeProducts}
-    Yves: login on Yves with provided credentials:    ${yves_company_user_buyer_email}
-    Yves: go to the PDP of the first available product
-    Yves: get sku of the concrete product on PDP
-    Yves: get sku of the abstract product on PDP
+   # Assign alternatives without making a product discontinued
+    Yves: go to PDP of the product with sku:    ${available_product_abstract_sku}
+    Yves: PDP contains/doesn't contain:    false    ${alternativeProducts}
     Zed: login on Zed with provided credentials:    ${zed_admin_email}
-    Zed: discontinue the following product:    ${got_abstract_product_sku}    ${got_concrete_product_sku}
+    Zed: go to second navigation item level:    Catalog    Products
+    Zed: click Action Button in a table for row that contains:    ${available_product_abstract_sku}    Edit
+    Wait Until Element Is Visible    ${zed_pdp_abstract_main_content_locator}
+    Zed: switch to the tab on 'Edit product' page:    Variants
+    Zed: click Action Button in Variant table for row that contains:    ${available_product_concrete_sku}    Edit
+    Wait Until Element Is Visible    ${zed_pdp_concrete_main_content_locator}
+    Zed: switch to the tab on 'Edit product' page:    Product Alternatives
+    Zed: add following alternative products to the concrete:    M21648
+    Yves: login on Yves with provided credentials:    ${yves_user_email}
+    Yves: go to the 'Home' page
+    Yves: go to PDP of the product with sku:    ${available_product_abstract_sku}
+    Yves: PDP contains/doesn't contain:    false    ${alternativeProducts}
+   # making product not available in Zed 
+    Zed: login on Zed with provided credentials:    ${zed_admin_email}
+    Zed: change product stock:    ${available_product_abstract_sku}    ${available_product_concrete_sku}    false    0  
+    Yves: login on Yves with provided credentials:    ${yves_user_email}
+    Yves: go to the 'Home' page
+    Yves: go to PDP of the product with sku:    ${available_product_abstract_sku}
+    Yves: PDP contains/doesn't contain:    true    ${alternativeProducts}
+    Yves: check product status:    alternative
+    Yves: check product not available on pdp
+    Yves: go to PDP of the product with sku:    M21648
+    Yves: check product section:    replacement
+   #  Discontinue a product in Zed
+    Zed: login on Zed with provided credentials:    ${zed_admin_email}
+    Zed: discontinue the following product:    ${available_product_abstract_sku}    ${available_product_concrete_sku}
     Zed: product is successfully discontinued
-    Zed: add following alternative products to the concrete:    M22613
-    Zed: submit the form
-    [Teardown]    Zed: undo discontinue the following product:    ${got_abstract_product_sku}    ${got_concrete_product_sku}
-
+    Yves: go to the 'Home' page
+    Yves: go to PDP of the product with sku:    ${available_product_abstract_sku}
+    Yves: check product status:    alternative
+    Yves: check product status:    discontinued
+    Yves: PDP contains/doesn't contain:    true    ${alternativeProducts}
+    Yves: go to PDP of the product with sku:    M21648
+    Yves: check product section:    replacement
+    [Teardown]    Run Keywords    Zed: login on Zed with provided credentials:    admin@spryker.com  
+    ...    AND    Zed: remove alternative product from the concrete:    ${available_product_abstract_sku}    ${available_product_concrete_sku}    M21648
+    ...    AND    Zed: change product stock:    ${available_product_abstract_sku}    ${available_product_concrete_sku}    true    20  
+    ...    AND    Zed: undo discontinue the following product:    ${available_product_abstract_sku}    ${available_product_concrete_sku}
+    
 Measurement_Units
     [Documentation]    Checks checkout with Measurement Unit product
     [Setup]    Run keywords    Yves: login on Yves with provided credentials:    ${yves_company_user_manager_and_buyer_email}


### PR DESCRIPTION
## PR Description
https://spryker.atlassian.net/browse/CC-21649

Alternative products and discontinued products

- Discontinue a product in Zed and assign alternatives → check in yves that product has labels "Discontinued" and "Have alternatives" and on PDP user sees a section for alternatives. Check that on PDP of the alternative product user sees a section "Alternative for"
- Assign alternatives without making a product discontinued → do not show alternatives in Yves
- Make a product not available in Zed and assign alternatives → check in yves that product has label "Have alternatives" and on PDP user sees a section for alternatives. Check that on PDP of the alternative product user sees a section "Alternative for"  
