### PR TITLE
b2c-smoke-zed-navigation ordering and naming

### DIFF
--- a/resources/pages/zed/zed_root_menus_page.robot
+++ b/resources/pages/zed/zed_root_menus_page.robot
@@ -1,0 +1,4 @@
+*** Variables ***
+${zed_first_navigation_menus_locator}    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'/') and not (contains(@href,'javascript'))])
+${zed_root_menu_icons_locator}    xpath=//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a
+${zed_second_navigation_menus_locator}    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'javascript')])

--- a/resources/steps/zed_root_menus_steps.robot
+++ b/resources/steps/zed_root_menus_steps.robot
@@ -1,0 +1,46 @@
+*** Settings ***
+Resource    ../common/common_zed.robot
+Resource    ../common/common.robot
+Resource    ../pages/zed/zed_root_menus_page.robot
+
+*** Keywords ***
+Zed: verify first navigation root menus
+    ${counter}=    Set Variable    1
+    ${first_navigation_count}=    Get Element Count    ${zed_first_navigation_menus_locator}
+    WHILE  ${counter} <= ${first_navigation_count}
+        Log    ${counter}
+        Click    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'/') and not (contains(@href,'javascript'))])[${counter}]
+        Sleep    3s
+        Wait Until Element Is Visible    ${zed_log_out_button}
+        ${counter}=    Evaluate    ${counter} + 1   
+    END
+
+Zed: verify root menu icons
+    ${counter}=    Set Variable    1
+    ${first_navigation_icon_count}=    Get Element Count    ${zed_root_menu_icons_locator}
+    WHILE  ${counter} <= ${first_navigation_icon_count}
+        Log    ${counter}
+        Page should contain element    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a/i)[${counter}]
+        ${counter}=    Evaluate    ${counter} + 1
+    END
+
+Zed: verify second navigation root menus
+    ${counter}=    Set Variable    1
+    ${first_navigation_count}=    Get Element Count    ${zed_second_navigation_menus_locator}
+    WHILE  ${counter} <= ${first_navigation_count}
+        ${counter_1}=    Set Variable    1
+        Log    ${counter}
+        Click    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'javascript')])[${counter}]
+        ${second_navigation_count}=    Get Element Count    xpath=((//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'javascript')])[${counter}]/ancestor::li//ul[contains(@class,'nav-second-level')]//a)
+            WHILE  ${counter_1} <= ${second_navigation_count}
+                ${node_state}=    Get Element Attribute    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'javascript')]/parent::li)[${counter}]    class
+                log    ${node_state}
+                IF    'active' not in '${node_state}'     Click    xpath=(//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'javascript')])[${counter}]
+                Click    xpath=((//ul[@id='side-menu']/li/a/span[@class='nav-label']/../../a[contains(@href,'javascript')])[${counter}]/ancestor::li//ul[contains(@class,'nav-second-level')]//a)[${counter_1}]
+                Wait Until Element Is Visible    ${zed_log_out_button}
+                Log    ${counter_1}
+                ${counter_1}=    Evaluate    ${counter_1} + 1   
+            END        
+        Wait Until Element Is Visible    ${zed_log_out_button}
+        ${counter}=    Evaluate    ${counter} + 1  
+    END

--- a/tests/smoke/smoke_b2c.robot
+++ b/tests/smoke/smoke_b2c.robot
@@ -26,10 +26,10 @@ Resource    ../../resources/steps/wishlist_steps.robot
 Resource    ../../resources/steps/zed_availability_steps.robot
 Resource    ../../resources/steps/zed_discount_steps.robot
 Resource    ../../resources/steps/zed_cms_page_steps.robot
-
 Resource    ../../resources/steps/zed_customer_steps.robot
 Resource    ../../resources/steps/zed_payment_methods_steps.robot
 Resource    ../../resources/steps/zed_dashboard_steps.robot
+Resource    ../../resources/steps/zed_root_menu_steps.robot
 
 *** Test Cases ***
 New_Customer_Registration
@@ -713,3 +713,10 @@ Add_to_cart_products_as_a_guest_user_and_register_during_checkout
      [Teardown]    Zed: delete customer:
     ...    || email                          ||
     ...    || abc${random}@gmail.com ||
+
+Zed_navigation_ordering_and_naming
+    [Documentation]    Verifying root menus and icons in zed
+    Zed: login on Zed with provided credentials:    ${zed_admin_email}
+    Zed: verify first navigation root menus
+    Zed: verify root menu icons
+    Zed: verify second navigation root menus


### PR DESCRIPTION
https://spryker.atlassian.net/browse/CC-21838

Zed Navigation ordering and naming

1. User sees next root menus:

* Dashboard
* Sales
* Customers
* Catalog
* Content
* Merchandising
* Marketplace
* Users
* Administration
* Maintenance

2. Each of them has icon and translated to DE for de admin
3. Gift Cart Balance page is situated under sales menu