### PR TITLE
added tad dms-off for GLUE store tests

### DIFF
--- a/tests/api/b2b/glue/utility_endpoints/stores/negative.robot
+++ b/tests/api/b2b/glue/utility_endpoints/stores/negative.robot
@@ -12,6 +12,8 @@ ENABLER
     API_test_setup
 
 Get_store_by_non_exist_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7427 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/NON_EXIST_STORE
     Then Response status code should be:    404
     And Response should return error code:    601

--- a/tests/api/b2b/glue/utility_endpoints/stores/positive.robot
+++ b/tests/api/b2b/glue/utility_endpoints/stores/positive.robot
@@ -12,6 +12,8 @@ ENABLER
     API_test_setup
 
 Get_all_availiable_stores
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -103,6 +105,8 @@ Get_all_availiable_stores
     And Response body has correct self link
 
 Get_store_by_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/${store.de}
     Then Response status code should be:    200
     And Response reason should be:    OK

--- a/tests/api/b2c/glue/utility_endpoints/stores/negative.robot
+++ b/tests/api/b2c/glue/utility_endpoints/stores/negative.robot
@@ -9,6 +9,8 @@ ENABLER
     API_test_setup
 
 Get_store_by_non_exist_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7427 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/NON_EXIST_STORE
     Then Response status code should be:    404
     And Response should return error code:    601

--- a/tests/api/b2c/glue/utility_endpoints/stores/positive.robot
+++ b/tests/api/b2c/glue/utility_endpoints/stores/positive.robot
@@ -11,6 +11,8 @@ ENABLER
 
 #get
 Get_all_availiable_stores
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -41,6 +43,8 @@ Get_all_availiable_stores
 
 
 Get_store_by_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/${store.de}
     Then Response status code should be:    200
     And Response reason should be:    OK

--- a/tests/api/mp_b2b/glue/utility_endpoints/stores/negative.robot
+++ b/tests/api/mp_b2b/glue/utility_endpoints/stores/negative.robot
@@ -9,6 +9,8 @@ ENABLER
     API_test_setup
 
 Get_store_by_non_exist_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7427 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/NON_EXIST_STORE
     Then Response status code should be:    404
     And Response should return error code:    601

--- a/tests/api/mp_b2b/glue/utility_endpoints/stores/positive.robot
+++ b/tests/api/mp_b2b/glue/utility_endpoints/stores/positive.robot
@@ -9,6 +9,8 @@ Default Tags    glue
 ENABLER
     API_test_setup
 Get_all_availiable_stores
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -39,6 +41,8 @@ Get_all_availiable_stores
 
 
 Get_store_by_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/${store.de}
     Then Response status code should be:    200
     And Response reason should be:    OK

--- a/tests/api/mp_b2c/glue/checkout_endpoints/checkout/positive.robot
+++ b/tests/api/mp_b2c/glue/checkout_endpoints/checkout/positive.robot
@@ -27,10 +27,10 @@ Create_order
 
 Create_order_include_orders
     [Setup]    Run Keywords    I get access token for the customer:    ${yves_user.email}
-    ...  AND    I set Headers:    Authorization=${token}
+    ...    AND    I set Headers:    Authorization=${token}
     ...    AND    Find or create customer cart
     ...    AND    Cleanup all items in the cart:    ${cart_id}
-    ...  AND    I send a POST request:    /carts/${cart_id}/items    {"data": {"type": "items","attributes": {"sku": "${product_availability.concrete_available_with_stock_and_never_out_of_stock_sku}","quantity": 1}}}
+    ...    AND    I send a POST request:    /carts/${cart_id}/items    {"data": {"type": "items","attributes": {"sku": "${product_availability.concrete_available_with_stock_and_never_out_of_stock_sku}","quantity": 1}}}
     When I send a POST request:    /checkout?include=orders    {"data": {"type": "checkout","attributes": {"customer": {"email": "${yves_user.email}","salutation": "${yves_user.salutation}","firstName": "${yves_user.first_name}","lastName": "${yves_user.last_name}"},"idCart": "${cart_id}","billingAddress": {"salutation": "${yves_user.salutation}","firstName": "${yves_user.first_name}","lastName": "${yves_user.last_name}","address1": "${default.address1}","address2": "${default.address2}","address3": "${default.address3}","zipCode": "${default.zipCode}","city": "${default.city}","iso2Code": "${default.iso2Code}","company": "${default.company}","phone": "${default.phone}","isDefaultBilling": False,"isDefaultShipping": False},"shippingAddress": {"salutation": "${yves_user.salutation}","firstName": "${yves_user.first_name}","lastName": "${yves_user.last_name}","address1": "${default.address1}","address2": "${default.address2}","address3": "${default.address3}","zipCode": "${default.zipCode}","city": "${default.city}","iso2Code": "${default.iso2Code}","company": "${default.company}","phone": "${default.phone}","isDefaultBilling": False,"isDefaultShipping": False},"payments": [{"paymentProviderName": "${payment.provider_name}","paymentMethodName": "${payment.method_name}","paymentSelection": "${payment.selection_name}"}],"shipment": {"idShipmentMethod": 1},"items": ["${product_availability.concrete_available_with_stock_and_never_out_of_stock_sku}"]}}}
     Then Response status code should be:    201
     And Response reason should be:    Created

--- a/tests/api/mp_b2c/glue/utility_endpoints/stores/negative.robot
+++ b/tests/api/mp_b2c/glue/utility_endpoints/stores/negative.robot
@@ -9,6 +9,8 @@ ENABLER
     API_test_setup
 
 Get_store_by_non_exist_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7427 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/NON_EXIST_STORE
     Then Response status code should be:    404
     And Response should return error code:    601

--- a/tests/api/mp_b2c/glue/utility_endpoints/stores/positive.robot
+++ b/tests/api/mp_b2c/glue/utility_endpoints/stores/positive.robot
@@ -10,6 +10,8 @@ ENABLER
 
 #get
 Get_all_availiable_stores
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -40,6 +42,8 @@ Get_all_availiable_stores
 
 
 Get_store_by_id
+    [Tags]    dms-off
+    [Documentation]    https://spryker.atlassian.net/browse/FRW-7430 Test has been skipped for dms-on shop. discussed with Platform team. Bug has low priority can be not fixed soon.
     When I send a GET request:    /stores/${store.de}
     Then Response status code should be:    200
     And Response reason should be:    OK


### PR DESCRIPTION
added tad dms-off for GLUE store tests. this tag exclude tests from dms-on shop run BUT will run tests for regular shop as it was before.


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
