### PR TITLE
fixed flaky api test

### DIFF
--- a/tests/api/b2b/glue/shopping_list_endpoints/shopping_list_items/positive.robot
+++ b/tests/api/b2b/glue/shopping_list_endpoints/shopping_list_items/positive.robot
@@ -472,12 +472,12 @@ Add_2_Configurable_products_but_with_different_configurations
    And Response body parameter should be:    [data][attributes][numberOfItems]    3
    And Response should contain the array of a certain size:    [included]    2
    And Response body parameter should be in:   [included][0][id]    ${shoppingListItemId1}    ${shoppingListItemId2}
-   And Response body parameter should be:   [included][0][attributes][quantity]    2
+   And Response body parameter should be in:   [included][0][attributes][quantity]    2    1
    And Response body parameter should be in:   [included][0][attributes][sku]    ${configurable_product.sku}    ${shoppingListItemId1}    ${shoppingListItemId2}
    And Response body parameter should be in:    [included][0][attributes][productConfigurationInstance][displayData]    {\"Preferred time of the day\":\"Morning\",\"Date\":\"10.10.2040\"}    {\"Preferred time of the day\":\"Afternoon\",\"Date\":\"11.11.2040\"}
    And Response body parameter should be in:    [included][0][attributes][productConfigurationInstance][isComplete]    True    False
    And Response body parameter should be in:   [included][1][id]    ${shoppingListItemId1}    ${shoppingListItemId2}    ${configurable_product.sku}
-   And Response body parameter should be:   [included][1][attributes][quantity]    1
+   And Response body parameter should be in:   [included][1][attributes][quantity]    1    2
    And Response body parameter should be in:   [included][1][attributes][sku]    ${shoppingListItemId1}    ${shoppingListItemId2}    ${configurable_product.sku}
    And Response body parameter should be in:    [included][1][attributes][productConfigurationInstance][displayData]    {\"Preferred time of the day\":\"Afternoon\",\"Date\":\"11.11.2040\"}    {\"Preferred time of the day\":\"Morning\",\"Date\":\"10.10.2040\"}
    And Response body parameter should be in:    [included][1][attributes][productConfigurationInstance][isComplete]    False    True


### PR DESCRIPTION
Test randomly failed for PostgreSQL DB because sorting for included items are not the same as for Maria DB.

We have added two configurable same products BUT with different configuration.

- first product in qty2
- second product in qty=1

Then we assert qty of items in the shopping list. The response has two product items in includes and receive product 2 then product one.

I have add flexibility. The row before says that we definitely should have 3 items
"And Response body parameter should be:    [data][attributes][numberOfItems]    3"
Thats why it doesn't meter include 0 or include 1 will have item qty=2


## Checklist
- [ x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
