### PR TITLE
CC-39227: fix Dynamic_multistore store-switcher wait under robotframework-browser 20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 # Robot Framework and core dependencies
 robotframework
 robotframework-pabot
-robotframework-browser
+# Pinned: 20.0.0 changed Get Text semantics for <select>/<input> (returns inputValue)
+# and Wait For Request behaviour; unpinned-latest broke master CI (CC-39227).
+# Bump deliberately and re-validate the UI suites.
+robotframework-browser==20.0.0
 robotframework-databaselibrary
 robotframework-requests
 robotframework-jsonlibrary

--- a/resources/common/common_yves.robot
+++ b/resources/common/common_yves.robot
@@ -340,7 +340,9 @@ Yves: wait until store switcher contains:
     Wait Until Element Is Visible    ${store_switcher_header_menu_item}
     FOR    ${index}    IN RANGE    0    ${tries}
         Disable Automatic Screenshots on Failure
-        ${storeAppears}=    Run Keyword And Return Status    Wait Until Element Contains    locator=${store_switcher_header_menu_item}    text=${store}    timeout=${timeout}
+        # `Get Text` (robotframework-browser >= 20.0.0) returns the input value for <select> elements,
+        # i.e. only the selected option. Wait for the new store's <option> node instead.
+        ${storeAppears}=    Run Keyword And Return Status    Wait For Elements State    ${store_switcher_header_menu_item}/option[contains(., '${store}')]    attached    timeout=${timeout}
         Restore Automatic Screenshots on Failure
         IF    '${storeAppears}'=='False'
             Run Keywords    Sleep    ${timeout}    AND    Reload


### PR DESCRIPTION
## Summary
- `Yves: wait until store switcher contains:` now waits for the store's `<option>` node instead of text-matching the `<select>`. robotframework-browser 20.0.0 changed `Get Text` on `<select>` to return the input value (selected option only), so the keyword could never see a newly created store and `Dynamic_multistore` failed in master with the misleading "Check P&S" message. The new wait works under both v19 and v20 semantics.
- Pin `robotframework-browser==20.0.0`: the image installed the unpinned latest on every build, which is how master went red without any code change.

Jira: [CC-39227](https://spryker.atlassian.net/browse/CC-39227)

## Test plan
- Local stack (deploy.ci.acceptance.mariadb.robot.yml, DMS on): `Dynamic_multistore` PASS; the switcher wait completes in 0.56s (previously 137s timeout-fail).
- Suite PR spryker/suite#728 pins this branch: SN-CI-FOCUSED Robot UI green twice (runs 27370122064, 27374829929).