### PR TITLE
Fix configurable-product cart unit-price assertion + timeout (CC-38992 follow-up)

### DIFF
--- a/resources/steps/shopping_carts_steps.robot
+++ b/resources/steps/shopping_carts_steps.robot
@@ -181,9 +181,9 @@ Yves: shopping cart contains product with unit price:
     IF    '${env}' in ['ui_b2b','ui_mp_b2b']
         Log    Unit price assertion skipped on ${env}: new cart UI renders item total only; per-row total is covered by other assertions in the test.
     ELSE IF    '${env}' in ['ui_suite']
-        Page Should Contain Element    xpath=//main//cart-items-list//product-item[contains(@data-qa,'component product-cart-item')]//*[@data-qa='cart-item-sku'][contains(text(),'${sku}')]/ancestor::product-item//*[contains(@data-qa,'cart-item-summary')]//span[contains(.,'${productPrice}')]    timeout=300ms
+        Page Should Contain Element    xpath=//main//cart-items-list//product-item[contains(@data-qa,'component product-cart-item')]//*[@data-qa='cart-item-sku'][contains(text(),'${sku}')]/ancestor::product-item//*[contains(@data-qa,'cart-item-summary')]//span[contains(.,'${productPrice}')]    timeout=${browser_timeout}
     ELSE
-        Page Should Contain Element    xpath=(//main[@class='page-layout-cart']//article[contains(@data-qa,'component product-card-item')]//a[contains(text(),'${productName}')]/following-sibling::span/span[contains(@class,'money-price__amount') and contains(.,'${productPrice}')]) | (//main[contains(@class,'cart')]//product-cart-item[contains(@data-qa,'component product-cart-item')]//a[contains(text(),'${productName}')]/following-sibling::span/span[contains(@class,'money-price__amount') and contains(.,'${productPrice}')])    timeout=300ms
+        Page Should Contain Element    xpath=(//main[@class='page-layout-cart']//article[contains(@data-qa,'component product-card-item')]//a[contains(text(),'${productName}')]/following-sibling::span/span[contains(@class,'money-price__amount') and contains(.,'${productPrice}')]) | (//main[contains(@class,'cart')]//product-cart-item[contains(@data-qa,'component product-cart-item')]//a[contains(text(),'${productName}')]/following-sibling::span/span[contains(@class,'money-price__amount') and contains(.,'${productPrice}')])    timeout=${browser_timeout}
     END
 
 Yves: shopping cart contains/doesn't contain the following elements:

--- a/tests/parallel_ui/suite/catalog/catalog.robot
+++ b/tests/parallel_ui/suite/catalog/catalog.robot
@@ -284,8 +284,9 @@ Configurable_Product_PDP_Shopping_List
     ...    || option one | option two ||
     ...    || 517        | 249        ||
     Yves: save product configuration
-    ### bug: https://spryker.atlassian.net/browse/CC-33647
-    Yves: shopping cart contains product with unit price:    ${configurable_product_concrete_sku}    ${configurable_product_name}    €249.00
+    ### bug: https://spryker.atlassian.net/browse/CC-33647 — configured option prices are not added to the
+    ### displayed cart unit price, so it stays the base product price (configurable_product_price_without_configurations).
+    Yves: shopping cart contains product with unit price:    ${configurable_product_concrete_sku}    ${configurable_product_name}    ${configurable_product_price_without_configurations}
     Yves: delete product from the shopping cart with name:    ${configurable_product_name}
     Yves: go to PDP of the product with sku:    ${configurable_product_abstract_sku}
     Yves: add product to the shopping list:    configProduct+${random}

--- a/tests/parallel_ui/suite/catalog/catalog.robot
+++ b/tests/parallel_ui/suite/catalog/catalog.robot
@@ -284,6 +284,9 @@ Configurable_Product_PDP_Shopping_List
     ...    || option one | option two ||
     ...    || 517        | 249        ||
     Yves: save product configuration
+    ### DIAG (temporary): capture the actual cart contents to determine the real configured-product unit price.
+    ${diag_cart_text}=    Get Text    xpath=//main
+    Log To Console    \n>>>DIAGCART_START>>>\n${diag_cart_text}\n<<<DIAGCART_END<<<\n
     ### bug: https://spryker.atlassian.net/browse/CC-33647 — configured option prices are not added to the
     ### displayed cart unit price, so it stays the base product price (configurable_product_price_without_configurations).
     Yves: shopping cart contains product with unit price:    ${configurable_product_concrete_sku}    ${configurable_product_name}    ${configurable_product_price_without_configurations}

--- a/tests/parallel_ui/suite/catalog/catalog.robot
+++ b/tests/parallel_ui/suite/catalog/catalog.robot
@@ -284,12 +284,9 @@ Configurable_Product_PDP_Shopping_List
     ...    || option one | option two ||
     ...    || 517        | 249        ||
     Yves: save product configuration
-    ### DIAG (temporary): capture the actual cart contents to determine the real configured-product unit price.
-    ${diag_cart_text}=    Get Text    xpath=//main
-    Log To Console    \n>>>DIAGCART_START>>>\n${diag_cart_text}\n<<<DIAGCART_END<<<\n
-    ### bug: https://spryker.atlassian.net/browse/CC-33647 — configured option prices are not added to the
-    ### displayed cart unit price, so it stays the base product price (configurable_product_price_without_configurations).
-    Yves: shopping cart contains product with unit price:    ${configurable_product_concrete_sku}    ${configurable_product_name}    ${configurable_product_price_without_configurations}
+    # Configured unit price = sum of the selected options (Option title 2 €517 + Option Two title 3 €249 = €766.00),
+    # matching the €882.00 assertion below for the 607/275 configuration.
+    Yves: shopping cart contains product with unit price:    ${configurable_product_concrete_sku}    ${configurable_product_name}    €766.00
     Yves: delete product from the shopping cart with name:    ${configurable_product_name}
     Yves: go to PDP of the product with sku:    ${configurable_product_abstract_sku}
     Yves: add product to the shopping list:    configProduct+${random}


### PR DESCRIPTION
Fixes the `Configurable_Product_PDP_Shopping_List` failure on the sharded Robot UI run (parallel_ui/suite), surfaced by the CI-tiering/dump-restore work (suite #669).

Two changes:
- **catalog.robot**: the cart unit-price assertion for the 517/249 configuration hardcoded `€249.00`, but the configured unit price is `€766.00` (Option title 2 €517 + Option Two title 3 €249) — verified against the actual dump-restore cart. Corrected to `€766.00`, matching the sibling `€882.00` assertion (607/275). The configuration **is** applied correctly; removed the stale `CC-33647` "options not added" note.
- **shopping_carts_steps.robot**: the cart unit-price check used `timeout=300ms`; the per-row total renders async after the configurator save, which flakes under CI parallel load. Use the standard `${browser_timeout}`.

Jira: https://spryker.atlassian.net/browse/CC-38992

**Test plan:** focused Robot UI run (parallel_ui/suite catalog) green against the dump-restore stack — verified via spryker/suite#669.