### PR TITLE
CC-38846 Fixed flacky `Get_search_suggestions_with_brand_and_currency `

### DIFF
--- a/tests/api/b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
@@ -243,7 +243,7 @@ Get_search_suggestions_with_brand_and_currency
     ...    ${brand_name}
     And Response should contain the array of a certain size:    [data][0][attributes][completion]    10
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
-    And Array element should contain property with value at least once:    [data][0][attributes][abstractProducts]    price    ${${abstract.alternative_products.product_3.price_chf}}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][price]    0
     And Response body has correct self link
 
 Get_search_suggestions_with_color

--- a/tests/api/b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
@@ -233,6 +233,9 @@ Get_search_suggestions_with_cms_page_collection
     And Response body has correct self link
 
 Get_search_suggestions_with_brand_and_currency
+    When I send a GET request:    /catalog-search-suggestions?q=${brand_name}
+    Then Response status code should be:    200
+    ${default_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
     When I send a GET request:    /catalog-search-suggestions?q=${brand_name}&currency=${currency.chf.code}
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -244,6 +247,8 @@ Get_search_suggestions_with_brand_and_currency
     And Response should contain the array of a certain size:    [data][0][attributes][completion]    10
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
     And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][price]    0
+    ${chf_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
+    And Should Not Be Equal As Integers    ${chf_price}    ${default_price}
     And Response body has correct self link
 
 Get_search_suggestions_with_color

--- a/tests/api/mp_b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
+++ b/tests/api/mp_b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
@@ -174,6 +174,9 @@ Get_search_suggestions_with_cms_page_collection
     And Response body has correct self link
 
 Get_search_suggestions_with_brand_and_currency
+    When I send a GET request:    /catalog-search-suggestions?q=${brand_name}&page[limit]=12
+    Then Response status code should be:    200
+    ${default_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
     When I send a GET request:    /catalog-search-suggestions?q=${brand_name}&currency=${currency.chf.code}&page[limit]=12
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -183,6 +186,8 @@ Get_search_suggestions_with_brand_and_currency
     And Response should contain the array of a certain size:    [data][0][attributes][completion]    10
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
     And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][price]    0
+    ${chf_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
+    And Should Not Be Equal As Integers    ${chf_price}    ${default_price}
 
 Get_search_suggestions_with_color
     When I send a GET request:    /catalog-search-suggestions?q=${color_name}

--- a/tests/api/mp_b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
+++ b/tests/api/mp_b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
@@ -182,7 +182,7 @@ Get_search_suggestions_with_brand_and_currency
     And Each array element of array in response should contain value:    [data][0][attributes][completion]    ${brand_name}
     And Response should contain the array of a certain size:    [data][0][attributes][completion]    10
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
-    And Array element should contain property with value at least once:    [data][0][attributes][abstractProducts]    price    ${${alternative_abstract_product.price_chf}}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][price]    0
 
 Get_search_suggestions_with_color
     When I send a GET request:    /catalog-search-suggestions?q=${color_name}


### PR DESCRIPTION
## PR Description
Fixes a flaky assertion in the `Get_search_suggestions_with_brand_and_currency` test (mp_b2b + suites).                                                                          

What: Replaced the assertion that checked a specific product's CHF price was present somewhere in the search suggestions, with a check that the first returned abstract product has price > 0.

Why: The endpoint hardcodes the suggestion result to 10 products (SuggestionByTypeQueryExpanderPlugin::SIZE = 10). The old assertion required one specific product (with CHF price 1130) to land within those top-10 Elasticsearch-ranked results. After https://github.com/spryker/suite/pull/584 changed the seeded catalog data, ES ranking shifted and that product is no longer reliably in the top-10 so the test fails intermittently even though search works correctly. The functionality isn't broken; the assertion was just too coupled to non-deterministic ranking.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/robotframework-suite-tests/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
