### PR TITLE
CC-39400 Fix CRUD_Product_Set ~180s P&S-drain flake

### DIFF
--- a/resources/common/common_yves.robot
+++ b/resources/common/common_yves.robot
@@ -448,6 +448,13 @@ Yves: go to newly created page by URL:
         ${page_not_published}=    Run Keyword And Return Status    Page Should Contain Element    xpath=//main//*[contains(text(),'ERROR 404')]
         Restore Automatic Screenshots on Failure
         IF    '${page_not_published}'=='True'
+            # CC-39400: the single create-time `--stop-when-empty` P&S drain can exit mid publish->sync
+            # cascade, and this loop otherwise only navigates with a cache-buster + sleeps -> the 404
+            # never clears and it runs to its full ~180s timeout. Re-trigger the worker while polling
+            # (same pattern as the PDP poll above) so the cascade actually finishes.
+            IF    ${index} == 5 or ${index} == 10 or ${index} == 15 or ${index} == 20
+                Trigger multistore p&s
+            END
             Sleep    ${delay}
         ELSE
             Exit For Loop


### PR DESCRIPTION
**CC-39400** — Fix `CRUD_Product_Set` ~180s P&S-drain flake.

The single create-time `--stop-when-empty` P&S drain can exit mid publish→sync cascade; the `Yves: go to newly created page by URL:` poll loop only cache-busted + slept, so the 404 never cleared and the test ran to its ~180s timeout (passed on rerun once storage warmed). Re-trigger the worker at poll iterations 5/10/15/20 (same pattern as the PDP poll in this keyword). Benefits all ~50 callers of the shared keyword.

Jira: https://spryker.atlassian.net/browse/CC-39400

Test plan: focused robot-ui CI green — `CRUD_Product_Set` PASSED in 73.1s (was 180s+ timeout).