### PR TITLE
Quarantine 3 recurring flaky Robot UI tests pending fix

### DIFF
--- a/tests/parallel_ui/suite/catalog/catalog.robot
+++ b/tests/parallel_ui/suite/catalog/catalog.robot
@@ -50,7 +50,7 @@ Catalog
     [Teardown]    Yves: check if cart is not empty and clear it
 
 Catalog_Actions
-    [Tags]    smoke    quick-add-to-cart     cart
+    [Tags]    smoke    quick-add-to-cart     cart    quarantine
     [Documentation]    Checks quick add to cart and product groups
     [Setup]    Create dynamic admin user in DB
     Zed: login on Zed with provided credentials:    ${dynamic_admin_user}

--- a/tests/parallel_ui/suite/checkout/checkout_guest.robot
+++ b/tests/parallel_ui/suite/checkout/checkout_guest.robot
@@ -13,7 +13,7 @@ Resource    ../../../../resources/steps/orders_management_steps.robot
 
 *** Test Cases ***
 Guest_Checkout
-    [Tags]    smoke
+    [Tags]    smoke    quarantine
     [Documentation]    Guest checkout with bundles, discounts and OMS
     [Setup]    Run keywords    Create dynamic admin user in DB
     ...    AND    Zed: login on Zed with provided credentials:    ${dynamic_admin_user}

--- a/tests/parallel_ui/suite/multistore/multistore_offer.robot
+++ b/tests/parallel_ui/suite/multistore/multistore_offer.robot
@@ -15,7 +15,7 @@ Resource    ../../../../resources/steps/products_steps.robot
 
 *** Test Cases ***
 Multistore_Product_Offer
-    [Tags]    smoke
+    [Tags]    smoke    quarantine
     [Documentation]    check product and offer multistore functionality.
     [Setup]    Run Keywords    Create dynamic customer in DB
     ...    AND    Zed: create dynamic merchant user:    Spryker


### PR DESCRIPTION
## Summary
- Tags `Catalog_Actions`, `Guest_Checkout`, and `Multistore_Product_Offer` with `quarantine` so they're excluded from the blocking Robot UI legs and picked up by the new non-blocking `robot-ui-quarantine` lane instead (spryker/suite#882).
- All three fail-then-pass on the existing rerun-once mechanism repeatedly.

Jira: https://spryker.atlassian.net/browse/CC-39555, https://spryker.atlassian.net/browse/CC-39669, https://spryker.atlassian.net/browse/CC-39670

## Test plan
- [ ] Paired with spryker/suite#882 (which pins this branch temporarily) to confirm `robot-ui-quarantine-detect` flips to true and `robot-ui-quarantine` runs these 3 tests non-blocking.
- [ ] Confirm the blocking Robot UI legs no longer execute these tests.