### PR TITLE
CC-39400 Re-drain P&S inside the delete-side 404 poll under DMS

### DIFF
--- a/resources/common/common_yves.robot
+++ b/resources/common/common_yves.robot
@@ -533,6 +533,13 @@ Yves: go to URL and refresh until 404 occurs:
         ${page_not_published}=    Run Keyword And Return Status    Page Should Contain Element    xpath=//main//*[contains(text(),'ERROR 404')]
         Restore Automatic Screenshots on Failure
         IF    '${page_not_published}'=='False'
+            # Under DMS the delete is a publish->sync cascade; the single pre-loop `--stop-when-empty`
+            # drain can exit between stages before sync removes the storefront storage entry, so the
+            # page stays live and this loop otherwise just refreshes+sleeps to its ~180s timeout.
+            # Re-drain the worker while polling (same pattern as the create-side poll) so it finishes.
+            IF    ${index} == 5 or ${index} == 10 or ${index} == 15 or ${index} == 20
+                Trigger multistore p&s
+            END
             Run Keyword    Sleep    ${delay}
         ELSE
             Exit For Loop


### PR DESCRIPTION
Stabilizes `CRUD_Product_Set` in the merchandising suite. Detail in [CC-39400](https://spryker.atlassian.net/browse/CC-39400).

The delete-side poll keyword `Yves: go to URL and refresh until 404 occurs:` re-triggers `Trigger multistore p&s` at iterations 5/10/15/20 (mirroring the create-side fix), so a stalled un-publish→sync cascade under DMS finishes instead of running the poll to its ~180s timeout.

**Test plan:** focused robot-ui CI (DMS=true, merchandising narrow) — `CRUD_Product_Set` PASSED in 106.7s; `3 tests, 3 passed, 0 failed`. Verified against suite composer-pin PR spryker/suite#925.