### PR TITLE
CC-39673 Adjusted B2B MP assertions for new demo company user data.

### DIFF
--- a/tests/api/mp_b2b/glue/company_endpoints/company_business_unit/positive.robot
+++ b/tests/api/mp_b2b/glue/company_endpoints/company_business_unit/positive.robot
@@ -72,11 +72,12 @@ Request_business_unit_by_id_with_include_address_and_company
     And Response body parameter should contain:    [data][relationships]    company-business-unit-addresses
     And Response body parameter should contain:    [data][relationships][company-business-unit-addresses][data][0][type]    company-business-unit-addresses
     And Response body parameter should not be EMPTY:    [data][relationships][company-business-unit-addresses][data][0][id]
-    And Response should contain the array of a certain size:    [included]  2
+    And Response should contain the array of a certain size:    [included]  3
     And Response include should contain certain entity type:    companies
     And Response include should contain certain entity type:    company-business-unit-addresses
     And Response body parameter should not be EMPTY:    [included][0][id]
     And Response body parameter should not be EMPTY:    [included][1][id]
+    And Response body parameter should not be EMPTY:    [included][2][id]
     And Each array element of array in response should contain property:    [included]    attributes
     And Response body parameter should not be EMPTY:    [included][0][attributes][isActive]
     And Response body parameter should not be EMPTY:    [included][0][attributes][name]
@@ -89,6 +90,14 @@ Request_business_unit_by_id_with_include_address_and_company
     And Response body parameter should not be EMPTY:    [included][1][attributes][phone]
     And Response body parameter should not be EMPTY:    [included][1][attributes][iso2Code]
     And Response body parameter should contain:     [included][1][attributes]    comment
+    And Response body parameter should not be EMPTY:    [included][2][attributes][address1]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][address2]
+    And Response body parameter should contain:     [included][2][attributes]    address3
+    And Response body parameter should not be EMPTY:    [included][2][attributes][zipCode]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][city]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][phone]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][iso2Code]
+    And Response body parameter should contain:     [included][2][attributes]    comment
     And Response body has correct self link internal
 
 Request_business_unit_by_mine_include_address_and_company
@@ -112,11 +121,12 @@ Request_business_unit_by_mine_include_address_and_company
     And Response body parameter should contain:    [data]    relationships
     And Response body parameter should contain:    [data][0][relationships][companies][data][0][type]   companies
     And Response body parameter should not be EMPTY:    [data][0][relationships][companies][data][0][id]
-    And Response should contain the array of a certain size:    [included]  2
+    And Response should contain the array of a certain size:    [included]  3
     And Response include should contain certain entity type:    companies
     And Response include should contain certain entity type:    company-business-unit-addresses
     And Response body parameter should not be EMPTY:    [included][0][id]
     And Response body parameter should not be EMPTY:    [included][1][id]
+    And Response body parameter should not be EMPTY:    [included][2][id]
     And Each array element of array in response should contain property:    [included]    attributes
     And Response body parameter should not be EMPTY:    [included][0][attributes][isActive]
     And Response body parameter should not be EMPTY:    [included][0][attributes][name]
@@ -129,4 +139,12 @@ Request_business_unit_by_mine_include_address_and_company
     And Response body parameter should not be EMPTY:    [included][1][attributes][phone]
     And Response body parameter should not be EMPTY:    [included][1][attributes][iso2Code]
     And Response body parameter should contain:     [included][1][attributes]    comment
+    And Response body parameter should not be EMPTY:    [included][2][attributes][address1]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][address2]
+    And Response body parameter should contain:     [included][2][attributes]    address3
+    And Response body parameter should not be EMPTY:    [included][2][attributes][zipCode]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][city]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][phone]
+    And Response body parameter should not be EMPTY:    [included][2][attributes][iso2Code]
+    And Response body parameter should contain:     [included][2][attributes]    comment
     And Response body has correct self link

--- a/tests/api/mp_b2b/glue/company_endpoints/company_users/positive.robot
+++ b/tests/api/mp_b2b/glue/company_endpoints/company_users/positive.robot
@@ -12,7 +12,7 @@ Retrieve_list_of_company_users
     Then Response status code should be:    200
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
-    And Response should contain the array of a certain size:    [data]    12
+    And Response should contain the array of a certain size:    [data]    13
     And Response should contain the array of a certain size:    [data][0]    4
     And Each array element of array in response should contain value:    [data]    type
     And Each array element of array in response should contain property with value:    [data]    type    company-users
@@ -113,11 +113,11 @@ Retrieve_company_users_by_mine
     Then Response status code should be:    200
     And Response reason should be:    OK
     And Response header parameter should be:    Content-Type    ${default_header_content_type}
-    And Response should contain the array of a certain size:    [data]  1
-    And Response body parameter should be:    [data][0][type]   company-users
-    And Response body parameter should not be EMPTY:    [data][0][id]
-    And Response body parameter should be:    [data][0][attributes][isActive]    True
-    And Response body parameter should be:    [data][0][attributes][isDefault]    False
+    And Response should contain the array of a certain size:    [data]  2
+    And Each array element of array in response should contain property with value:    [data]    type    company-users
+    And Each array element of array in response should contain property with value NOT in:    [data]    [id]    None
+    And Each array element of array in response should contain property with value in:    [data]    attributes.isActive    True
+    And Each array element of array in response should contain property with value in:    [data]    attributes.isDefault    True    False
     And Response body has correct self link
 
 Retrieve_list_of_company_users_with_include_customers_and_filtered_by_company_role

--- a/tests/api/mp_b2b/glue/company_endpoints/company_users/positive.robot
+++ b/tests/api/mp_b2b/glue/company_endpoints/company_users/positive.robot
@@ -116,7 +116,7 @@ Retrieve_company_users_by_mine
     And Response should contain the array of a certain size:    [data]  2
     And Each array element of array in response should contain property with value:    [data]    type    company-users
     And Each array element of array in response should contain property with value NOT in:    [data]    [id]    None
-    And Each array element of array in response should contain property with value in:    [data]    attributes.isActive    True
+    And Each array element of array in response should contain property with value in:    [data]    attributes.isActive    True    True
     And Each array element of array in response should contain property with value in:    [data]    attributes.isDefault    True    False
     And Response body has correct self link
 


### PR DESCRIPTION
CC-39673 https://github.com/spryker-shop/b2b-demo-marketplace/pull/1231 extends the B2B MP demo data to make the shop easier to demo: sonia@acme.com gets a second company-user seat in the top-level ACME business unit (her original HR seat becomes the default one), and the HR business unit gets an additional address (Pariser Platz 1, Berlin).                                                           
