### PR TITLE
CC-39674 Fix option group name expectations (b2b-icp base)

### DIFF
--- a/resources/environments/environments_api_b2b.json
+++ b/resources/environments/environments_api_b2b.json
@@ -443,6 +443,7 @@
        },
        "product_options":{
           "option_1":"OP_2_year_waranty",
+          "option_1_group_name":"Warranty",
           "option_1_name":"Two (2) year limited warranty",
           "option_2":"OP_insurance"
        },

--- a/resources/environments/environments_api_mp_b2b.json
+++ b/resources/environments/environments_api_mp_b2b.json
@@ -592,6 +592,7 @@
         "measurement_unit_m":"METR",
         "product_options":{
             "option_1":"OP_2_year_waranty",
+            "option_1_group_name":"Warranty",
             "option_1_name":"Two (2) year limited warranty",
             "option_2":"OP_insurance"
         },

--- a/resources/environments/environments_api_mp_b2b.json
+++ b/resources/environments/environments_api_mp_b2b.json
@@ -315,25 +315,25 @@
             "product_options":{
                 "OP_1":{
                     "id":"OP_1_year_waranty",
-                    "option_group_name":"Three (3) year limited warranty",
+                    "option_group_name":"Warranty",
                     "sku":"OP_1_year_waranty",
                     "option_name":"One (1) year limited warranty"
                 },
                 "OP_2":{
                     "id":"OP_2_year_waranty",
-                    "option_group_name":"Three (3) year limited warranty",
+                    "option_group_name":"Warranty",
                     "sku":"OP_2_year_waranty",
                     "option_name":"Two (2) year limited warranty"
                 },
                 "OP_3":{
                     "id":"OP_3_year_waranty",
-                    "option_group_name":"Three (3) year limited warranty",
+                    "option_group_name":"Warranty",
                     "sku":"OP_3_year_waranty",
                     "option_name":"Three (3) year limited warranty"
                 },
                 "OP_insurance":{
                     "id":"OP_insurance",
-                    "option_group_name":"Two (2) year insurance coverage",
+                    "option_group_name":"Insurance",
                     "sku":"OP_insurance",
                     "option_name":"Two (2) year insurance coverage"
                 }
@@ -481,25 +481,25 @@
             "product_options":{
                 "OP_1":{
                     "id":"OP_1_year_waranty",
-                    "option_group_name":"Three (3) year limited warranty",
+                    "option_group_name":"Warranty",
                     "sku":"OP_1_year_waranty",
                     "option_name":"One (1) year limited warranty"
                 },
                 "OP_2":{
                     "id":"OP_2_year_waranty",
-                    "option_group_name":"Three (3) year limited warranty",
+                    "option_group_name":"Warranty",
                     "sku":"OP_2_year_waranty",
                     "option_name":"Two (2) year limited warranty"
                 },
                 "OP_3":{
                     "id":"OP_3_year_waranty",
-                    "option_group_name":"Three (3) year limited warranty",
+                    "option_group_name":"Warranty",
                     "sku":"OP_3_year_waranty",
                     "option_name":"Three (3) year limited warranty"
                 },
                 "OP_insurance":{
                     "id":"OP_insurance",
-                    "option_group_name":"Two (2) year insurance coverage",
+                    "option_group_name":"Insurance",
                     "sku":"OP_insurance",
                     "option_name":"Two (2) year insurance coverage"
                 }

--- a/tests/api/b2b/glue/checkout_endpoints/checkout/positive.robot
+++ b/tests/api/b2b/glue/checkout_endpoints/checkout/positive.robot
@@ -348,7 +348,7 @@ Create_order_with_weight_product_&_product_options
     And Response body parameter should be:    [included][0][attributes][items][1][sku]    ${concrete.with_options.sku}
     And Response body parameter should be:
     ...    [included][0][attributes][items][1][productOptions][0][optionGroupName]
-    ...    Three (3) year limited warranty
+    ...    Warranty
     And Response body parameter should be:
     ...    [included][0][attributes][items][1][productOptions][0][sku]
     ...    ${product_options.option_1}

--- a/tests/api/b2b/glue/checkout_endpoints/checkout/positive.robot
+++ b/tests/api/b2b/glue/checkout_endpoints/checkout/positive.robot
@@ -348,7 +348,7 @@ Create_order_with_weight_product_&_product_options
     And Response body parameter should be:    [included][0][attributes][items][1][sku]    ${concrete.with_options.sku}
     And Response body parameter should be:
     ...    [included][0][attributes][items][1][productOptions][0][optionGroupName]
-    ...    Warranty
+    ...    ${product_options.option_1_group_name}
     And Response body parameter should be:
     ...    [included][0][attributes][items][1][productOptions][0][sku]
     ...    ${product_options.option_1}

--- a/tests/api/mp_b2b/glue/checkout_endpoints/checkout/positive.robot
+++ b/tests/api/mp_b2b/glue/checkout_endpoints/checkout/positive.robot
@@ -213,7 +213,7 @@ Create_order_with_weight_product_&_product_options
     #product_2
     And Response body parameter should be:    [included][0][attributes][items][1][name]    ${abstract_product.product_with_options.concrete_name}
     And Response body parameter should be:    [included][0][attributes][items][1][sku]    ${abstract_product.product_with_options.concrete_sku}
-    And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][optionGroupName]    Warranty
+    And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][optionGroupName]    ${product_options.option_1_group_name}
     And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][sku]    ${product_options.option_1}
     And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][optionName]    ${product_options.option_1_name}
     And Response body parameter should be greater than:    [included][0][attributes][items][1][productOptions][0][price]    0

--- a/tests/api/mp_b2b/glue/checkout_endpoints/checkout/positive.robot
+++ b/tests/api/mp_b2b/glue/checkout_endpoints/checkout/positive.robot
@@ -213,7 +213,7 @@ Create_order_with_weight_product_&_product_options
     #product_2
     And Response body parameter should be:    [included][0][attributes][items][1][name]    ${abstract_product.product_with_options.concrete_name}
     And Response body parameter should be:    [included][0][attributes][items][1][sku]    ${abstract_product.product_with_options.concrete_sku}
-    And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][optionGroupName]    Three (3) year limited warranty
+    And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][optionGroupName]    Warranty
     And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][sku]    ${product_options.option_1}
     And Response body parameter should be:    [included][0][attributes][items][1][productOptions][0][optionName]    ${product_options.option_1_name}
     And Response body parameter should be greater than:    [included][0][attributes][items][1][productOptions][0][price]    0


### PR DESCRIPTION
Branched from b2b-icp-starting-point. The b2b-demo-marketplace ProductOptionWriterStep fix renders the option group label from group_name_translation_key instead of the last option value, so update the expected group names:
- b2b + mp_b2b: option group name "Three (3) year limited warranty" ->
  "Warranty"; "Two (2) year insurance coverage" -> "Insurance"
Option VALUE names (option_name) unchanged; b2c variant untouched.

## PR Description
Add a meaningful description here that will let us know what you want to fix with this PR or what functionality you want to add.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/robotframework-suite-tests/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
