### PR TITLE
CC-38846 Fix flaky Get_search_suggestions_with_brand_and_currency on the b2b-icp base

### DIFF
--- a/tests/api/b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
+++ b/tests/api/b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
@@ -233,6 +233,9 @@ Get_search_suggestions_with_cms_page_collection
     And Response body has correct self link
 
 Get_search_suggestions_with_brand_and_currency
+    When I send a GET request:    /catalog-search-suggestions?q=${brand_name}
+    Then Response status code should be:    200
+    ${default_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
     When I send a GET request:    /catalog-search-suggestions?q=${brand_name}&currency=${currency.chf.code}
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -243,7 +246,9 @@ Get_search_suggestions_with_brand_and_currency
     ...    ${brand_name}
     And Response should contain the array of a certain size:    [data][0][attributes][completion]    10
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
-    And Array element should contain property with value at least once:    [data][0][attributes][abstractProducts]    price    ${${abstract.alternative_products.product_3.price_chf}}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][price]    0
+    ${chf_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
+    And Should Not Be Equal As Integers    ${chf_price}    ${default_price}
     And Response body has correct self link
 
 Get_search_suggestions_with_color

--- a/tests/api/mp_b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
+++ b/tests/api/mp_b2b/glue/search_endpoints/catalog_search_suggestions/positive.robot
@@ -174,6 +174,9 @@ Get_search_suggestions_with_cms_page_collection
     And Response body has correct self link
 
 Get_search_suggestions_with_brand_and_currency
+    When I send a GET request:    /catalog-search-suggestions?q=${brand_name}
+    Then Response status code should be:    200
+    ${default_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
     When I send a GET request:    /catalog-search-suggestions?q=${brand_name}&currency=${currency.chf.code}
     Then Response status code should be:    200
     And Response reason should be:    OK
@@ -182,7 +185,9 @@ Get_search_suggestions_with_brand_and_currency
     And Each array element of array in response should contain value:    [data][0][attributes][completion]    ${brand_name}
     And Response should contain the array of a certain size:    [data][0][attributes][completion]    10
     And Response should contain the array of a certain size:    [data][0][attributes][abstractProducts]    10
-    And Array element should contain property with value at least once:    [data][0][attributes][abstractProducts]    price    ${${alternative_abstract_product.price_chf}}
+    And Response body parameter should be greater than:    [data][0][attributes][abstractProducts][0][price]    0
+    ${chf_price}=    Set Variable    ${response_body['data'][0]['attributes']['abstractProducts'][0]['price']}
+    And Should Not Be Equal As Integers    ${chf_price}    ${default_price}
     And Response body has correct self link
 
 Get_search_suggestions_with_color


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/CC-38846

`Get_search_suggestions_with_brand_and_currency` was de-flaked on `master` by #1077, but this branch has diverged and never received it — and `b2b-demo-marketplace`'s `Robot / API B2B` job installs `dev-b2b-icp-starting-point` explicitly, so it still runs the pre-fix assert and fails intermittently.

This ports #1077 to both affected trees (`b2b`, `mp_b2b`), adapted to this branch's own query shapes. The old assert required a hardcoded CHF price to appear somewhere in the top 10 suggestions, which breaks whenever Elasticsearch reorders equally-scoring products; the replacement compares the first product's default-currency price against its CHF price, so it is order-independent.

#### Test plan

- `b2b-demo-marketplace` [#1279](https://github.com/spryker-shop/b2b-demo-marketplace/pull/1279) temporarily pins `Robot / API B2B` to this branch → `Robotframework.Tests.Api.B2B.Glue.Search Endpoints.Catalog Search Suggestions.Positive.Get_search_suggestions_with_brand_and_currency`
